### PR TITLE
Add GraalVM CE v19.0.0 - Polyglot Virtual Machine for JVM, JavaScript, LLVM..

### DIFF
--- a/bucket/graalvm.json
+++ b/bucket/graalvm.json
@@ -11,7 +11,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "github": "https://github.com/oracle/graal"
+        "github": "https://github.com/oracle/graal",
+        "re": "vm-([\\d\\w.-]+)"
     },
     "autoupdate": {
         "url": "https://github.com/oracle/graal/releases/download/vm-$version/graalvm-ce-windows-amd64-$version.zip",

--- a/bucket/graalvm.json
+++ b/bucket/graalvm.json
@@ -1,0 +1,23 @@
+{
+    "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
+    "version": "19.0.0",
+    "homepage": "https://graalvm.org",
+    "license": "GPL-2.0",
+    "url": "https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-windows-amd64-19.0.0.zip",
+    "hash": "c60094dffbf1a8dda3a6901c3ed60f30e03bdfb88d9258f1ef32223d48c94817",
+    "extract_dir": "graalvm-ce-19.0.0",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "github": "https://github.com/oracle/graal"
+    },
+    "autoupdate": {
+        "url": "https://github.com/oracle/graal/releases/download/vm-$version/graalvm-ce-windows-amd64-$version.zip",
+        "extract_dir": "graalvm-ce-$version",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
GraalVM is a polyglot JVM/JIT supporting Java/Scala/Kotlin, JavaScript/NodeJS, Ruby, Python, R + any-LLVM based languages, with fast & compact AOT/native image executables
https://www.graalvm.org

GraalVM 19.0 Released - First production release of the revolutionary polyglot virtual machine / @GraalVM
https://medium.com/graalvm/announcing-graalvm-19-4590cf354df8
https://www.graalvm.org/docs/release-notes/#1900
https://www.graalvm.org/downloads/
https://www.graalvm.org/docs/reference-manual/graal-updater/
https://www.graalvm.org/docs/reference-manual/aot-compilation/