### PR TITLE
openjdk14: Rename to openjdk-ea

### DIFF
--- a/bucket/openjdk-ea.json
+++ b/bucket/openjdk-ea.json
@@ -1,6 +1,6 @@
 {
-    "description": "Official production-ready open-source builds of OpenJDK 14",
-    "homepage": "https://jdk.java.net/14",
+    "description": "Official Early-Access Builds of OpenJDK",
+    "homepage": "https://jdk.java.net/",
     "version": "14-18-ea",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
@@ -15,6 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
+        "url": "https://jdk.java.net/14",
         "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },


### PR DESCRIPTION
JDK 14 is Early-Access Build now and should be named as `openjdk-ea`.