### PR TITLE
AdoptOpenJDK 13: Add releases

### DIFF
--- a/bucket/adopt13-hotspot-jre.json
+++ b/bucket/adopt13-hotspot-jre.json
@@ -1,19 +1,19 @@
 {
     "description": "AdoptOpenJDK 13 JRE with Oracle HotSpot JVM",
     "homepage": "https://adoptopenjdk.net",
-    "version": "13-33",
+    "version": "13.0.1-9",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jre_x64_windows_hotspot_13_33.zip",
-            "hash": "cdcc461336ea110c376722d7e4050076387d584e1c1309d3b6b1903f5f447b16"
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9/OpenJDK13U-jre_x64_windows_hotspot_13.0.1_9.zip",
+            "hash": "fd3fc1085f29bab990b31bd96c38cfca439de317e97340351e88f7c77a7e070b"
         },
         "32bit": {
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jre_x86-32_windows_hotspot_13_33.zip",
-            "hash": "90b8815238b3eae76bdcbebfc749d0088d115b9b94aba2554a4807d50b77de07"
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9/OpenJDK13U-jre_x86-32_windows_hotspot_13.0.1_9.zip",
+            "hash": "7b45a7d67b4d71133091f3713a016ec93686fec3b0174cbaf7a2c71906905e36"
         }
     },
-    "extract_dir": "jdk-13+33-jre",
+    "extract_dir": "jdk-13.0.1+9-jre",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"

--- a/bucket/adopt13-hotspot-jre.json
+++ b/bucket/adopt13-hotspot-jre.json
@@ -1,0 +1,42 @@
+{
+    "description": "AdoptOpenJDK 13 JRE with Oracle HotSpot JVM",
+    "homepage": "https://adoptopenjdk.net",
+    "version": "13-33",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jre_x64_windows_hotspot_13_33.zip",
+            "hash": "cdcc461336ea110c376722d7e4050076387d584e1c1309d3b6b1903f5f447b16"
+        },
+        "32bit": {
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jre_x86-32_windows_hotspot_13_33.zip",
+            "hash": "90b8815238b3eae76bdcbebfc749d0088d115b9b94aba2554a4807d50b77de07"
+        }
+    },
+    "extract_dir": "jdk-13+33-jre",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk13?openjdk_impl=hotspot&os=windows&arch=x64&release=latest&type=jre",
+        "jp": "$.binaries[0].binary_link",
+        "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/$matchUrl/OpenJDK$matchJdkU-jre_x64_windows_hotspot_$matchMajor_$matchBuild.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/$matchUrl/OpenJDK$matchJdkU-jre_x86-32_windows_hotspot_$matchMajor_$matchBuild.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256.txt",
+            "find": "^([a-fA-F0-9]+)\\s"
+        },
+        "extract_dir": "jdk-$matchMajor+$matchBuild-jre"
+    }
+}

--- a/bucket/adopt13-hotspot.json
+++ b/bucket/adopt13-hotspot.json
@@ -1,0 +1,42 @@
+{
+    "description": "AdoptOpenJDK 13 with Oracle HotSpot JVM",
+    "homepage": "https://adoptopenjdk.net",
+    "version": "13-33",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_x64_windows_hotspot_13_33.zip",
+            "hash": "65d71a954167d538c7a260e64d9868ceffe60edd1108817a9c44fddf60d13569"
+        },
+        "32bit": {
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_x86-32_windows_hotspot_13_33.zip",
+            "hash": "076ec1da83805929322946bffdd7a99380ec7d1e6cfbd8eb6a6c880f8d89eda1"
+        }
+    },
+    "extract_dir": "jdk-13+33",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk13?openjdk_impl=hotspot&os=windows&arch=x64&release=latest&type=jdk",
+        "jp": "$.binaries[0].binary_link",
+        "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/$matchUrl/OpenJDK$matchJdkU-jdk_x64_windows_hotspot_$matchMajor_$matchBuild.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/$matchUrl/OpenJDK$matchJdkU-jdk_x86-32_windows_hotspot_$matchMajor_$matchBuild.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256.txt",
+            "find": "^([a-fA-F0-9]+)\\s"
+        },
+        "extract_dir": "jdk-$matchMajor+$matchBuild"
+    }
+}

--- a/bucket/adopt13-hotspot.json
+++ b/bucket/adopt13-hotspot.json
@@ -1,19 +1,19 @@
 {
     "description": "AdoptOpenJDK 13 with Oracle HotSpot JVM",
     "homepage": "https://adoptopenjdk.net",
-    "version": "13-33",
+    "version": "13.0.1-9",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_x64_windows_hotspot_13_33.zip",
-            "hash": "65d71a954167d538c7a260e64d9868ceffe60edd1108817a9c44fddf60d13569"
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9/OpenJDK13U-jdk_x64_windows_hotspot_13.0.1_9.zip",
+            "hash": "69132fdf7a7316244af59ed26b89d159584e62b0021165e2742115c767522b29"
         },
         "32bit": {
-            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/OpenJDK13U-jdk_x86-32_windows_hotspot_13_33.zip",
-            "hash": "076ec1da83805929322946bffdd7a99380ec7d1e6cfbd8eb6a6c880f8d89eda1"
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9/OpenJDK13U-jdk_x86-32_windows_hotspot_13.0.1_9.zip",
+            "hash": "c1f64b17b54870122c63c6f5944ec54b6407f031fb9a74e0e3d59e695d252cd8"
         }
     },
-    "extract_dir": "jdk-13+33",
+    "extract_dir": "jdk-13.0.1+9",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"

--- a/bucket/adopt13-openj9-jre.json
+++ b/bucket/adopt13-openj9-jre.json
@@ -1,0 +1,35 @@
+{
+    "description": "AdoptOpenJDK 13 JRE with Eclipse OpenJ9 JVM",
+    "homepage": "https://adoptopenjdk.net",
+    "version": "13.0.1-9-0.17.0",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0,EPL-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9_openj9-0.17.0/OpenJDK13U-jre_x64_windows_openj9_13.0.1_9_openj9-0.17.0.zip",
+            "hash": "5a0de9b809f1890912b6c7f9bd5ae17699a771782d69a270493b8e42d709ef05"
+        }
+    },
+    "extract_dir": "jdk-13.0.1+9-jre",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk13?openjdk_impl=openj9&os=windows&arch=x64&release=latest&type=jre",
+        "jp": "$.binaries[0].binary_link",
+        "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
+        "replace": "${major}-${build}${jvmver}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/$matchUrl.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256.txt",
+            "find": "^([a-fA-F0-9]+)\\s"
+        },
+        "extract_dir": "jdk-$matchMajor+$matchBuild-jre"
+    }
+}

--- a/bucket/adopt13-openj9.json
+++ b/bucket/adopt13-openj9.json
@@ -1,0 +1,35 @@
+{
+    "description": "AdoptOpenJDK 13 with Eclipse OpenJ9 JVM",
+    "homepage": "https://adoptopenjdk.net",
+    "version": "13.0.1-9-0.17.0",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0,EPL-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.1%2B9_openj9-0.17.0/OpenJDK13U-jdk_x64_windows_openj9_13.0.1_9_openj9-0.17.0.zip",
+            "hash": "6f5ff90fbf877144a17325d0fc506fbb164df69a16a90d79e6bd0dc47e29c2c8"
+        }
+    },
+    "extract_dir": "jdk-13.0.1+9",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk13?openjdk_impl=openj9&os=windows&arch=x64&release=latest&type=jdk",
+        "jp": "$.binaries[0].binary_link",
+        "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
+        "replace": "${major}-${build}${jvmver}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/$matchUrl.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256.txt",
+            "find": "^([a-fA-F0-9]+)\\s"
+        },
+        "extract_dir": "jdk-$matchMajor+$matchBuild"
+    }
+}


### PR DESCRIPTION
This PR adds the following releases:  
`adopt13-hotspot`  
`adopt13-hotspot-jre`  
`adopt13-openj9`  
`adopt13-openj9-jre`

~Note: The HotSpot release versions point to `jdk-13+33` because a 32-bit build is not yet available for `jdk-13.0.1+9`.~

Edit: All versions now point to `13.0.1+9`.