### PR TITLE
Export GRAALVM_HOME on install.

### DIFF
--- a/bucket/graalvm-nightly.json
+++ b/bucket/graalvm-nightly.json
@@ -8,7 +8,8 @@
     "extract_dir": "graalvm-ce-java11-20.1.0-dev",
     "env_add_path": "bin",
     "env_set": {
-        "JAVA_HOME": "$dir"
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
     },
     "checkver": {
         "github": "https://github.com/graalvm/graalvm-ce-dev-builds",

--- a/bucket/graalvm.json
+++ b/bucket/graalvm.json
@@ -8,7 +8,8 @@
     "extract_dir": "graalvm-ce-java11-20.0.0",
     "env_add_path": "bin",
     "env_set": {
-        "JAVA_HOME": "$dir"
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
     },
     "checkver": {
         "github": "https://github.com/graalvm/graalvm-ce-builds",

--- a/bucket/graalvm11-nightly.json
+++ b/bucket/graalvm11-nightly.json
@@ -8,7 +8,8 @@
     "extract_dir": "graalvm-ce-java11-20.1.0-dev",
     "env_add_path": "bin",
     "env_set": {
-        "JAVA_HOME": "$dir"
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
     },
     "checkver": {
         "github": "https://github.com/graalvm/graalvm-ce-dev-builds",

--- a/bucket/graalvm11.json
+++ b/bucket/graalvm11.json
@@ -8,7 +8,8 @@
     "extract_dir": "graalvm-ce-java11-20.0.0",
     "env_add_path": "bin",
     "env_set": {
-        "JAVA_HOME": "$dir"
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
     },
     "checkver": {
         "github": "https://github.com/graalvm/graalvm-ce-builds",

--- a/bucket/graalvm8-nightly.json
+++ b/bucket/graalvm8-nightly.json
@@ -8,7 +8,8 @@
     "extract_dir": "graalvm-ce-java8-20.1.0-dev",
     "env_add_path": "bin",
     "env_set": {
-        "JAVA_HOME": "$dir"
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
     },
     "checkver": {
         "github": "https://github.com/graalvm/graalvm-ce-dev-builds",

--- a/bucket/graalvm8.json
+++ b/bucket/graalvm8.json
@@ -8,7 +8,8 @@
     "extract_dir": "graalvm-ce-java8-20.0.0",
     "env_add_path": "bin",
     "env_set": {
-        "JAVA_HOME": "$dir"
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
     },
     "checkver": {
         "github": "https://github.com/graalvm/graalvm-ce-builds",


### PR DESCRIPTION
Most applications expect GRAALVM_HOME to be present when GraalVM is
installed.

See the documentation from quarkus: https://quarkus.io/guides/building-native-image