### PR TITLE
A bunch of fixes for Liberica installers.

### DIFF
--- a/bucket/liberica-full-jre.json
+++ b/bucket/liberica-full-jre.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica-full-lts-jre.json
+++ b/bucket/liberica-full-lts-jre.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica-full-lts.json
+++ b/bucket/liberica-full-lts.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica-full.json
+++ b/bucket/liberica-full.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica-jre.json
+++ b/bucket/liberica-jre.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica-lite-lts.json
+++ b/bucket/liberica-lite-lts.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-lite&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica-lite-lts.json
+++ b/bucket/liberica-lite-lts.json
@@ -13,7 +13,7 @@
             "hash": "sha1:eaeda9868cfa5a31879698594367e96503f45dc4"
         }
     },
-    "extract_dir": "jdk-11.0.6",
+    "extract_dir": "jdk-11.0.6-lite",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -37,6 +37,6 @@
             "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
             "jsonpath": "$.sha1"
         },
-        "extract_dir": "jdk-$matchMajor"
+        "extract_dir": "jdk-$matchMajor-lite"
     }
 }

--- a/bucket/liberica-lite.json
+++ b/bucket/liberica-lite.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica-lts-jre.json
+++ b/bucket/liberica-lts-jre.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica-lts.json
+++ b/bucket/liberica-lts.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica.json
+++ b/bucket/liberica.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica11-full-jre.json
+++ b/bucket/liberica11-full-jre.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica11-full.json
+++ b/bucket/liberica11-full.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica11-jre.json
+++ b/bucket/liberica11-jre.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica11-lite.json
+++ b/bucket/liberica11-lite.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica11-lite.json
+++ b/bucket/liberica11-lite.json
@@ -13,7 +13,7 @@
             "hash": "sha1:eaeda9868cfa5a31879698594367e96503f45dc4"
         }
     },
-    "extract_dir": "jdk-11.0.6",
+    "extract_dir": "jdk-11.0.6-lite",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -37,6 +37,6 @@
             "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
             "jsonpath": "$.sha1"
         },
-        "extract_dir": "jdk-$matchMajor"
+        "extract_dir": "jdk-$matchMajor-lite"
     }
 }

--- a/bucket/liberica11.json
+++ b/bucket/liberica11.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica13-lite.json
+++ b/bucket/liberica13-lite.json
@@ -13,7 +13,7 @@
             "hash": "sha1:167bf76d72f552dcfb83439b342163c2bd4a0177"
         }
     },
-    "extract_dir": "jdk-13.0.2",
+    "extract_dir": "jdk-13.0.2-lite",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"

--- a/bucket/liberica13.json
+++ b/bucket/liberica13.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/13.0.2%2B9/bellsoft-jdk13.0.2%2B9-windows-amd64.zip",
-            "hash": "sha1:214106b3aeb9f3fd1800efffc9c447acd7f6a19a"
+            "hash": "sha1:653876cd70a20ed8eaa3a6fe915c5fa02fdf2544"
         },
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/13.0.2%2B9/bellsoft-jdk13.0.2%2B9-windows-i586.zip",
-            "hash": "sha1:1a302ec32e393758f75ed5527144df17b4d5a068"
+            "hash": "sha1:3152d20417c78522595f63e2cd6a22c2677e367c"
         }
     },
     "extract_dir": "jdk-13.0.2",

--- a/bucket/liberica14-full-jre.json
+++ b/bucket/liberica14-full-jre.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=14&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica14-full.json
+++ b/bucket/liberica14-full.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=14&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica14-jre.json
+++ b/bucket/liberica14-jre.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=14&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica14-lite.json
+++ b/bucket/liberica14-lite.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=14&bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {

--- a/bucket/liberica14.json
+++ b/bucket/liberica14.json
@@ -21,7 +21,7 @@
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=14&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
-        "regex": "(?<major>[\\d.]+?)(?:\\.0\\.0)?(?:\\+)(?<build>[\\d]+)",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },
     "autoupdate": {


### PR DESCRIPTION
1. Removed a redundant capture group for trailing zeroes. Recently API was fixed accordingly to JEP-322 (A version number never has trailing zero elements. If an element and all those that follow it logically have the value zero then all of them are omitted.).
2. Regular bundles for 13.0.2+9 were reuploaded as they contained FX libraries by mistake, so I updated their checksums.
3. Fixed extract directories for 11.0.6 and 13.0.2 lite bundles. All subsequent releases will follow the next rules: lite bundles are extracted into jdk-<VNUM>-lite directory, regulars into jdk-<VNUM> and full into jdk-<VNUM>-full.