### PR TITLE
Migrate usages of AdoptOpenJDK API from v2 to v3

### DIFF
--- a/bucket/adopt11-hotspot-jre-nightly.json
+++ b/bucket/adopt11-hotspot-jre-nightly.json
@@ -25,8 +25,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk11?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ea?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?jdk(?<major>[\\d]+)u-(?<date>(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2})))",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt11-hotspot-jre.json
+++ b/bucket/adopt11-hotspot-jre.json
@@ -19,8 +19,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"
     },

--- a/bucket/adopt11-hotspot-nightly.json
+++ b/bucket/adopt11-hotspot-nightly.json
@@ -25,8 +25,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk11?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ea?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?jdk(?<major>[\\d]+)u-(?<date>(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2})))",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt11-hotspot.json
+++ b/bucket/adopt11-hotspot.json
@@ -19,8 +19,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"
     },

--- a/bucket/adopt11-openj9-jre-nightly.json
+++ b/bucket/adopt11-openj9-jre-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk11?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ea?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt11-openj9-jre.json
+++ b/bucket/adopt11-openj9-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt11-openj9-nightly.json
+++ b/bucket/adopt11-openj9-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk11?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ea?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt11-openj9-xl-jre-nightly.json
+++ b/bucket/adopt11-openj9-xl-jre-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk11?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ea?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt11-openj9-xl-jre.json
+++ b/bucket/adopt11-openj9-xl-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt11-openj9-xl-nightly.json
+++ b/bucket/adopt11-openj9-xl-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk11?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ea?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt11-openj9-xl.json
+++ b/bucket/adopt11-openj9-xl.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt11-openj9.json
+++ b/bucket/adopt11-openj9.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt14-hotspot-jre-nightly.json
+++ b/bucket/adopt14-hotspot-jre-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk14?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ea?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?jdk(?<major>[\\d]+)u-(?<date>(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2})))",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt14-hotspot-jre.json
+++ b/bucket/adopt14-hotspot-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"
     },

--- a/bucket/adopt14-hotspot-nightly.json
+++ b/bucket/adopt14-hotspot-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk14?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ea?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt14-hotspot.json
+++ b/bucket/adopt14-hotspot.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"
     },

--- a/bucket/adopt14-openj9-jre-nightly.json
+++ b/bucket/adopt14-openj9-jre-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk14?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ea?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt14-openj9-jre.json
+++ b/bucket/adopt14-openj9-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt14-openj9-nightly.json
+++ b/bucket/adopt14-openj9-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk14?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ea?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt14-openj9-xl-jre-nightly.json
+++ b/bucket/adopt14-openj9-xl-jre-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk14?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ea?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt14-openj9-xl-jre.json
+++ b/bucket/adopt14-openj9-xl-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt14-openj9-xl-nightly.json
+++ b/bucket/adopt14-openj9-xl-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk14?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ea?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt14-openj9-xl.json
+++ b/bucket/adopt14-openj9-xl.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt14-openj9.json
+++ b/bucket/adopt14-openj9.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt8-hotspot-jre-nightly.json
+++ b/bucket/adopt8-hotspot-jre-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk8?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ea?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?jdk(?<major>[\\d]+)u-(?<date>(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2})))",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt8-hotspot-jre.json
+++ b/bucket/adopt8-hotspot-jre.json
@@ -19,8 +19,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk8?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk(?<major>[\\d]+)(?<update>u[\\d]+)-(?<build>b[\\d]+)))/",
         "replace": "${major}${update}-${build}"
     },

--- a/bucket/adopt8-hotspot-nightly.json
+++ b/bucket/adopt8-hotspot-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk8?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ea?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?jdk(?<major>[\\d]+)u-(?<date>(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2})))",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt8-hotspot.json
+++ b/bucket/adopt8-hotspot.json
@@ -19,8 +19,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk8?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk(?<major>[\\d]+)(?<update>u[\\d]+)-(?<build>b[\\d]+)))/",
         "replace": "${major}${update}-${build}"
     },

--- a/bucket/adopt8-openj9-jre-nightly.json
+++ b/bucket/adopt8-openj9-jre-nightly.json
@@ -25,8 +25,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk8?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ea?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?jdk(?<major>[\\d]+)u-(?<date>(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2})))",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt8-openj9-jre.json
+++ b/bucket/adopt8-openj9-jre.json
@@ -19,8 +19,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk8?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?/(?<tag>jdk(?<major>[\\d]+)(?<update>u[\\d]+)-(?<build>b[\\d]+)(?<patch>[\\d.]*)(?:(?:_openj9?)(?<jvmver>-[\\d.]+))?))/",
         "replace": "${major}${update}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt8-openj9-nightly.json
+++ b/bucket/adopt8-openj9-nightly.json
@@ -25,8 +25,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk8?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ea?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?jdk(?<major>[\\d]+)u-(?<date>(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2})))",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt8-openj9-xl-jre-nightly.json
+++ b/bucket/adopt8-openj9-xl-jre-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk8?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ea?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt8-openj9-xl-jre.json
+++ b/bucket/adopt8-openj9-xl-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk8?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?/(?<tag>jdk(?<major>[\\d]+)(?<update>u[\\d]+)-(?<build>b[\\d]+)(?<patch>[\\d.]*)(?:(?:_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}${update}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt8-openj9-xl-nightly.json
+++ b/bucket/adopt8-openj9-xl-nightly.json
@@ -21,8 +21,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/nightly/openjdk8?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ea?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<year>[\\d]{4})-(?<month>[\\d]{2})-(?<day>[\\d]{2})-(?<hour>[\\d]{2})-(?<minute>[\\d]{2}).*?).zip",
         "replace": "${year}${month}${day}${hour}${minute}"
     },

--- a/bucket/adopt8-openj9-xl.json
+++ b/bucket/adopt8-openj9-xl.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk8?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?/(?<tag>jdk(?<major>[\\d]+)(?<update>u[\\d]+)-(?<build>b[\\d]+)(?<patch>[\\d.]*)(?:(?:_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}${update}-${build}${patch}${jvmver}"
     },

--- a/bucket/adopt8-openj9.json
+++ b/bucket/adopt8-openj9.json
@@ -19,8 +19,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk8?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?/(?<tag>jdk(?<major>[\\d]+)(?<update>u[\\d]+)-(?<build>b[\\d]+)(?<patch>[\\d.]*)(?:(?:_openj9?)(?<jvmver>-[\\d.]+))?))/",
         "replace": "${major}${update}-${build}${patch}${jvmver}"
     },

--- a/bucket/adoptopenjdk-hotspot-jre.json
+++ b/bucket/adoptopenjdk-hotspot-jre.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"

--- a/bucket/adoptopenjdk-hotspot-jre.json
+++ b/bucket/adoptopenjdk-hotspot-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"
     },

--- a/bucket/adoptopenjdk-hotspot.json
+++ b/bucket/adoptopenjdk-hotspot.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"
     },

--- a/bucket/adoptopenjdk-hotspot.json
+++ b/bucket/adoptopenjdk-hotspot.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"

--- a/bucket/adoptopenjdk-lts-hotspot-jre.json
+++ b/bucket/adoptopenjdk-lts-hotspot-jre.json
@@ -19,8 +19,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"
     },

--- a/bucket/adoptopenjdk-lts-hotspot-jre.json
+++ b/bucket/adoptopenjdk-lts-hotspot-jre.json
@@ -19,7 +19,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&lts=true&jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"

--- a/bucket/adoptopenjdk-lts-hotspot.json
+++ b/bucket/adoptopenjdk-lts-hotspot.json
@@ -19,7 +19,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&lts=true&jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"

--- a/bucket/adoptopenjdk-lts-hotspot.json
+++ b/bucket/adoptopenjdk-lts-hotspot.json
@@ -19,8 +19,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=hotspot&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]*)(?:\\%2B|\\+)(?<build>[\\d]+)))/",
         "replace": "${major}-${build}"
     },

--- a/bucket/adoptopenjdk-lts-openj9-jre.json
+++ b/bucket/adoptopenjdk-lts-openj9-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adoptopenjdk-lts-openj9-jre.json
+++ b/bucket/adoptopenjdk-lts-openj9-jre.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&lts=true&jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"

--- a/bucket/adoptopenjdk-lts-openj9-xl-jre.json
+++ b/bucket/adoptopenjdk-lts-openj9-xl-jre.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&lts=true&jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"

--- a/bucket/adoptopenjdk-lts-openj9-xl-jre.json
+++ b/bucket/adoptopenjdk-lts-openj9-xl-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adoptopenjdk-lts-openj9-xl.json
+++ b/bucket/adoptopenjdk-lts-openj9-xl.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&lts=true&jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"

--- a/bucket/adoptopenjdk-lts-openj9-xl.json
+++ b/bucket/adoptopenjdk-lts-openj9-xl.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adoptopenjdk-lts-openj9.json
+++ b/bucket/adoptopenjdk-lts-openj9.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk11?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adoptopenjdk-lts-openj9.json
+++ b/bucket/adoptopenjdk-lts-openj9.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/11/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&lts=true&jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"

--- a/bucket/adoptopenjdk-openj9-jre.json
+++ b/bucket/adoptopenjdk-openj9-jre.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"

--- a/bucket/adoptopenjdk-openj9-jre.json
+++ b/bucket/adoptopenjdk-openj9-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adoptopenjdk-openj9-xl-jre.json
+++ b/bucket/adoptopenjdk-openj9-xl-jre.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jre",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adoptopenjdk-openj9-xl-jre.json
+++ b/bucket/adoptopenjdk-openj9-xl-jre.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"

--- a/bucket/adoptopenjdk-openj9-xl.json
+++ b/bucket/adoptopenjdk-openj9-xl.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"

--- a/bucket/adoptopenjdk-openj9-xl.json
+++ b/bucket/adoptopenjdk-openj9-xl.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=openj9&heap_size=large&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=large&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },

--- a/bucket/adoptopenjdk-openj9.json
+++ b/bucket/adoptopenjdk-openj9.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "url": "https://api.adoptopenjdk.net/v3/assets/version/%5B8%2C%29?release_type=ga&jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
         "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"

--- a/bucket/adoptopenjdk-openj9.json
+++ b/bucket/adoptopenjdk-openj9.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.adoptopenjdk.net/v2/info/releases/openjdk14?openjdk_impl=openj9&heap_size=normal&os=windows&arch=x64&release=latest&type=jdk",
-        "jp": "$.binaries[0].binary_link",
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/14/ga?jvm_impl=openj9&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=adoptopenjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
         "re": "https://github.com/(?<url>.*?(?<tag>jdk-(?<major>(?<jdk>[\\d]+)[\\d.]+)(?:\\%2B|\\+)(?<build>[\\d]+)(?<patch>[\\d.]*)(?:(?<oj>_openj9?)(?<jvmver>-[\\d.]+))?)/.*?).zip",
         "replace": "${major}-${build}${patch}${jvmver}"
     },


### PR DESCRIPTION
Closes #102.

This PR migrates usages of the AdoptOpenJDK API from v2 to v3. 
The only modifications are to `checkver.url` and `checkver.jp` such that they should resolve to the same binary archive URL as before.

