### PR TITLE
Fixed problems with installing Liberica JDK 8

### DIFF
--- a/bucket/liberica8-full-jre.json
+++ b/bucket/liberica8-full-jre.json
@@ -13,7 +13,7 @@
             "hash": "2cfb367e660f690b4e8029a00fe12ef72730bcd1671286a18f562095f3ff59ab"
         }
     },
-    "extract_dir": "jre8u252",
+    "extract_dir": "jre8u252-full",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"

--- a/bucket/liberica8-full-jre.json
+++ b/bucket/liberica8-full-jre.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/8u252%2B9/bellsoft-jre8u252%2B9-windows-amd64-full.zip",
-            "hash": "e17e14a66583349f397410d70e126998064abd5a3ecf567dd5bd1e5c187fd51f"
+            "hash": "b3beb2c7fdc22855beb0ce410a2ad7e2d7e4d5d448db554f46340053d6967fbb"
         },
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/8u252%2B9/bellsoft-jre8u252%2B9-windows-i586-full.zip",
-            "hash": "1f1fc9f40f64797675a7c7cd0dcfa515f18354b418e7a5cf47e1c4eb1134240a"
+            "hash": "2cfb367e660f690b4e8029a00fe12ef72730bcd1671286a18f562095f3ff59ab"
         }
     },
     "extract_dir": "jre8u252",

--- a/bucket/liberica8-full.json
+++ b/bucket/liberica8-full.json
@@ -13,7 +13,7 @@
             "hash": "2296165ee44f3ed65c226bb0b35de5002ad55ff2bbec0b719002c1e397c5b6c7"
         }
     },
-    "extract_dir": "jdk8u252",
+    "extract_dir": "jdk8u252-full",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"

--- a/bucket/liberica8-full.json
+++ b/bucket/liberica8-full.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/8u252%2B9/bellsoft-jdk8u252%2B9-windows-amd64-full.zip",
-            "hash": "f7267642e6a39074b3ec612e1ba3f6ac7faf2bd342b155e079f0e72bbfca8b9e"
+            "hash": "ae7ac518a13c4cb844f7d3f6b4a040abcdb86f238d899ea228ef16753f49422c"
         },
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/8u252%2B9/bellsoft-jdk8u252%2B9-windows-i586-full.zip",
-            "hash": "08b1c3dc67b8a1feb47fb2735728d144ad8da6fd0034a58c7ed8d80383c35299"
+            "hash": "2296165ee44f3ed65c226bb0b35de5002ad55ff2bbec0b719002c1e397c5b6c7"
         }
     },
     "extract_dir": "jdk8u252",

--- a/bucket/liberica8-jre.json
+++ b/bucket/liberica8-jre.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/8u252%2B9/bellsoft-jre8u252%2B9-windows-amd64.zip",
-            "hash": "568e579a5f05fbc95fb788e0852fb9355a065260adec86b02622c62fe65c3e7b"
+            "hash": "01d2446a062330bf69d9321bea0d3f62225e916cf7de3ffd577dac17f3379908"
         },
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/8u252%2B9/bellsoft-jre8u252%2B9-windows-i586.zip",
-            "hash": "73ffece670f48e59c6a253289fc85545ffd5cd4d8e0d19c882ab5ad5f4259157"
+            "hash": "139495a0d34df3f1731c8dc67f96b9fe7406d48075ff75c0f177da6cc067f653"
         }
     },
     "extract_dir": "jre8u252",

--- a/bucket/liberica8.json
+++ b/bucket/liberica8.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/8u252%2B9/bellsoft-jdk8u252%2B9-windows-amd64.zip",
-            "hash": "63ae6142ef40eb86d119b9c1d33bfb725ac7beab46dea4cc0f0a5d19f559af4d"
+            "hash": "1a559f4474bbb47434156ea4a86567f46755f41a2087f8370e0526b0cb84882e"
         },
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/8u252%2B9/bellsoft-jdk8u252%2B9-windows-i586.zip",
-            "hash": "5a61018cdf2acd2a33b4aec0c3d87ff0c333acedcfb2cda2a02de6c6a858c687"
+            "hash": "46208fee63ab9ee10c52f1e08ce5bc5b7262baacf4df4b6d1069be63e374230f"
         }
     },
     "extract_dir": "jdk8u252",


### PR DESCRIPTION
1) Fixed wrong checksums caused by caching issues.
2) Fixed extract_dir for full bundles.