### PR TITLE
Update OpenJDK Checkver page to OpenJDK 15

### DIFF
--- a/bucket/openjdk.json
+++ b/bucket/openjdk.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/14/",
+        "url": "https://jdk.java.net/15/",
         "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },


### PR DESCRIPTION
With checkver updated, autoupdate would be able to update Scoop

> openjdk: 15.0.1-9 (scoop version is 14.0.2-12) autoupdate available