### PR TITLE
oraclejre8: Update to version 8u271

### DIFF
--- a/bucket/oraclejre8.json
+++ b/bucket/oraclejre8.json
@@ -1,37 +1,21 @@
 {
     "description": "Oracle JRE 8",
     "homepage": "https://www.java.com/",
-    "version": "8u261",
+    "version": "8u271",
     "license": "https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html",
     "architecture": {
         "64bit": {
-            "url": "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=242991_a4634525489241b9a9e1aa73d9e118e6#/dl.tar.gz",
-            "hash": "edd4a4568582ff50fb9d575169f5a3ceab26e80f6ecb7b04d133fff061881a8f"
+            "url": "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=243738_61ae65e088624f5aaa0b1d2d801acb16#/dl.tar.gz",
+            "hash": "9e7c4fa38502707ded59c461b77d0a0e1ff9cd98b6f25ccf1d615a45e0f36f12"
         },
         "32bit": {
-            "url": "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=242989_a4634525489241b9a9e1aa73d9e118e6#/dl.tar.gz",
-            "hash": "afe59fe721f7e047fdbfe552e674ba105a656b44ca34fada937856ff549f4e5f"
+            "url": "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=243736_61ae65e088624f5aaa0b1d2d801acb16#/dl.tar.gz",
+            "hash": "b49af1f8ff7ab97c7517aaac46458d4f8b64df09e5049b97927bd2ab3a232045"
         }
     },
-    "extract_dir": "jre1.8.0_261",
+    "extract_dir": "jre1.8.0_271",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
-    },
-    "checkver": {
-        "url": "https://www.java.com/en/download/manual.jsp",
-        "regex": "(?smi).*Recommended Version 8 Update (?<update>[\\d]+).*https://javadl.oracle.com/webapps/download/AutoDL\\?BundleId=(?<bundleida>[\\d]+)_(?<bundlea>[\\da-f]+)\">.*?Windows Offline.*https://javadl.oracle.com/webapps/download/AutoDL\\?BundleId=(?<bundleidb>[\\d]+)_(?<bundleb>[\\da-f]+)\">.*?Windows Offline \\(64-bit\\)",
-        "replace": "8u${update}"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=242991_$matchBundleb#/dl.tar.gz"
-            },
-            "32bit": {
-                "url": "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=242989_$matchBundlea#/dl.tar.gz"
-            }
-        },
-        "extract_dir": "jre1.8.0_$matchUpdate"
     }
 }


### PR DESCRIPTION
Disable autoupdate, whole download page is rendered in JavaScript, unable to parse it.