### PR TITLE
openjdk8: Use the unaltered builds from Red Hat

### DIFF
--- a/bucket/openjdk8-redhat-jre.json
+++ b/bucket/openjdk8-redhat-jre.json
@@ -1,0 +1,31 @@
+{
+    "description": "Unaltered builds from the OpenJDK mercurial JDK8u code stream, built by Red Hat",
+    "homepage": "https://adoptopenjdk.net/upstream.html",
+    "version": "8u272-b10",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jre_x64_windows_8u272b10.zip",
+            "hash": "4407ff03d39b05c5a09c4083279e4cdd03c14e37f96c8312ce9e58cff6086ba4"
+        }
+    },
+    "extract_dir": "openjdk-8u272-b10-jre",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=openjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
+        "re": "https://github.com/(?<url>.*?(?<tag>jdk(?<major>[\\d]+)(?<update>u[\\d]+)-(?<build>b[\\d]+)(?<patch>[\\d.]*)))/",
+        "replace": "${major}${update}-${build}${patch}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/AdoptOpenJDK/openjdk$matchMajor-upstream-binaries/releases/download/jdk$version/OpenJDK$matchMajorU-jre_x64_windows_$matchMajor$matchUpdate$matchBuild.zip"
+            }
+        },
+        "extract_dir": "openjdk-$version-jre"
+    }
+}

--- a/bucket/openjdk8-redhat.json
+++ b/bucket/openjdk8-redhat.json
@@ -1,0 +1,31 @@
+{
+    "description": "Unaltered builds from the OpenJDK mercurial JDK8u code stream, built by Red Hat",
+    "homepage": "https://adoptopenjdk.net/upstream.html",
+    "version": "8u272-b10",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_windows_8u272b10.zip",
+            "hash": "63fe8a555ae6553bd6f6f0937135c31e9adbb3b2ac85232e495596d39f396b1d"
+        }
+    },
+    "extract_dir": "openjdk-8u272-b10",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=openjdk&page_size=1&sort_order=DESC",
+        "jp": "$..binaries[0].package.link",
+        "re": "https://github.com/(?<url>.*?(?<tag>jdk(?<major>[\\d]+)(?<update>u[\\d]+)-(?<build>b[\\d]+)(?<patch>[\\d.]*)))/",
+        "replace": "${major}${update}-${build}${patch}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/AdoptOpenJDK/openjdk$matchMajor-upstream-binaries/releases/download/jdk$version/OpenJDK$matchMajorU-jdk_x64_windows_$matchMajor$matchUpdate$matchBuild.zip"
+            }
+        },
+        "extract_dir": "openjdk-$version"
+    }
+}


### PR DESCRIPTION
Related issue #100 