### PR TITLE
oraclejre8: Add checkver

### DIFF
--- a/bucket/oraclejre8.json
+++ b/bucket/oraclejre8.json
@@ -17,5 +17,10 @@
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://orasites-prodapp.cec.ocp.oraclecloud.com/content/published/api/v1.1/items/COREFA37E773006D4BE183DB8D7F504C5718?channelToken=1f7d2611846d4457b213dfc9048724dc",
+        "regex": "\"latest8Version\":\"(?<long>(?<ver>[\\d.]+)_(?<build>[\\d]+))\".*?\"secID\":\"(?<secid>[\\da-f]{32})\".*?\"win_offline_bundle\":\"(?<w32bundle>[\\d]+)\".*?\"win_x64_bundle\":\"(?<w64bundle>[\\d]+)\"",
+        "replace": "8u${build}"
     }
 }


### PR DESCRIPTION
Still unable to get the actual bundleid. The correct bundleid can be calculated by adding `1` to the windows offline packages (`win_offline_bundle` and `win_x64_bundle`). The bundleid change after each new release.