### PR TITLE
openjdk: Update checkver to version 16

### DIFF
--- a/bucket/openjdk.json
+++ b/bucket/openjdk.json
@@ -15,7 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/15/",
+        "url": "https://jdk.java.net/16/",
         "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },


### PR DESCRIPTION
Updating checkver will allow auto updater to detect v16 and update accordingly