### PR TITLE
Fix broken zulumc installer 💉

### DIFF
--- a/bucket/zulumc.json
+++ b/bucket/zulumc.json
@@ -21,7 +21,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://cdn.azul.com/zmc/bin/zmc$version-ca-win_x64.zip",
+                "url": "https://cdn.azul.com/zmc/bin/zmc$version-ca-win_x64.zip",
                 "extract_dir": "zmc$version-ca-win_x64\\Zulu Mission Control"
             }
         }

--- a/bucket/zulumc.json
+++ b/bucket/zulumc.json
@@ -1,28 +1,28 @@
 {
-    "homepage": "https://www.azul.com/products/zulu-mission-control",
     "version": "8.1.0.42",
-    "description": "Zulu Mission Control",
+    "description": "A build of JDK Mission Control, an open source Java runtime profiling and monitoring utility",
+    "homepage": "https://www.azul.com/products/components/zulu-mission-control/",
     "license": "UPL-1.0",
     "architecture": {
         "64bit": {
             "url": "https://cdn.azul.com/zmc/bin/zmc8.1.0.42-ca-win_x64.zip",
             "hash": "a430e6b797c805d4e0e40bd66fbff79ff77d3de4b5394a75c6596c09abcb7143",
-            "extract_dir": "zmc8.1.0.42-ca-win_x64"
+            "extract_dir": "zmc8.1.0.42-ca-win_x64\\Azul Mission Control"
         }
     },
+    "bin": "zmc.exe",
     "shortcuts": [
         [
             "zmc.exe",
             "Zulu Mission Control"
         ]
     ],
-    "persist": "configuration",
-    "checkver": "zmc([\\d.]+)(?<eaca>-EA|-ca)?-win",
+    "checkver": "zmc([\\d.]+)-ca-win",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cdn.azul.com/zmc/bin/zmc$version$matchEaca-win_x64.zip",
-                "extract_dir": "zmc$version$matchEaca-win_x64"
+                "url": "http://cdn.azul.com/zmc/bin/zmc$version-ca-win_x64.zip",
+                "extract_dir": "zmc$version-ca-win_x64\\Zulu Mission Control"
             }
         }
     }


### PR DESCRIPTION
The current manifest has wrong entries for extract directory and hence the install is incorrect. Additionally, persistence causes the app to break at runtime.
```powershell
❯ scoop install zulumc
WARN  Scoop uses 'aria2c' for multi-connection downloads.
WARN  Should it cause issues, run 'scoop config aria2-enabled false' to disable it.
Installing 'zulumc' (8.1.0.42) [64bit]
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: e6fabd|OK  |   3.7MiB/s|D:/scoop/cache/zulumc#8.1.0.42#https_cdn.azul.com_zmc_bin_zmc8.1.0.42-ca-win_x64.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of zmc8.1.0.42-ca-win_x64.zip ... ok.
Extracting zmc8.1.0.42-ca-win_x64.zip ... done.
Linking D:\scoop\apps\zulumc\current => D:\scoop\apps\zulumc\8.1.0.42
Creating shortcut for Zulu Mission Control (zmc.exe) failed: Couldn't find D:\scoop\apps\zulumc\current\zmc.exe
Persisting configuration
'zulumc' (8.1.0.42) was installed successfully!

❯ zmc
zmc: The term 'zmc' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

The current PR fixes both.