### PR TITLE
Rollback ms jdk11 lts version

### DIFF
--- a/bucket/microsoft11-jdk.json
+++ b/bucket/microsoft11-jdk.json
@@ -1,15 +1,15 @@
 {
     "description": "The Microsoft Build of OpenJDK is a no-cost long-term supported distribution and Microsoft's way to collaborate and contribute to the Java ecosystem.",
     "homepage": "https://www.microsoft.com/openjdk/",
-    "version": "17.35.1",
+    "version": "11.0.12.7.1",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://aka.ms/download-jdk/microsoft-jdk-17.35.1-windows-x64.zip",
-            "hash": "9dd44c04f7910f473f48df3432043b4e125a70fe70cf1095afd5b2480a90582d"
+            "url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.12.7.1-windows-x64.zip",
+            "hash": "c520c316353c6b0f8a4f8be3763664e44473b57f1e078922d5d2a8d3a8e84041"
         }
     },
-    "extract_dir": "jdk-17.35.1+",
+    "extract_dir": "jdk-11.0.12+7",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"


### PR DESCRIPTION
Current  microsoft11-jdk version figured to jdk 17.
I'm not sure but it's look like a mistake.
After run scoop update microsoft11-jdk this app was broken.