### PR TITLE
Recover OracleJDK 8,11,17

### DIFF
--- a/bucket/oraclejdk-lts.json
+++ b/bucket/oraclejdk-lts.json
@@ -1,0 +1,37 @@
+{
+    "description": "Oracle JDK 17",
+    "homepage": "https://www.oracle.com/technetwork/java/javase/overview/index.html",
+    "version": "17.0.1",
+    "license": "https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.oracle.com/java/17/archive/jdk-17.0.1_windows-x64_bin.zip",
+            "hash": "97b2db1db24a26a029e58af95260e7bd8226accf4095b7326b7d1b41de5b5bbb"
+        }
+    },
+    "cookie": {
+        "oraclelicense": "accept-securebackup-cookie"
+    },
+    "extract_dir": "jdk-17.0.1",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html",
+        "re": "otn-pub/java/jdk/(?<path>(?<major>[\\d.]+)\\+(?<build>[\\d]+)/(?<hash>[a-fA-F0-9]{32})/jdk-(?:.*?)_windows-x64_bin.zip)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$matchPath"
+            }
+        },
+        "hash": {
+            "url": "https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html",
+            "find": "$basename.*([a-fA-F0-9]{64})\"};"
+        },
+        "extract_dir": "jdk-$matchMajor"
+    }
+}

--- a/bucket/oraclejdk.json
+++ b/bucket/oraclejdk.json
@@ -1,0 +1,37 @@
+{
+    "description": "Oracle JDK 17",
+    "homepage": "https://www.oracle.com/technetwork/java/javase/overview/index.html",
+    "version": "17.0.1",
+    "license": "https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.oracle.com/java/17/archive/jdk-17.0.1_windows-x64_bin.zip",
+            "hash": "97b2db1db24a26a029e58af95260e7bd8226accf4095b7326b7d1b41de5b5bbb"
+        }
+    },
+    "cookie": {
+        "oraclelicense": "accept-securebackup-cookie"
+    },
+    "extract_dir": "jdk-17.0.1",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html",
+        "re": "otn-pub/java/jdk/(?<path>(?<major>[\\d.]+)\\+(?<build>[\\d]+)/(?<hash>[a-fA-F0-9]{32})/jdk-(?:.*?)_windows-x64_bin.zip)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$matchPath"
+            }
+        },
+        "hash": {
+            "url": "https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html",
+            "find": "$basename.*([a-fA-F0-9]{64})\"};"
+        },
+        "extract_dir": "jdk-$matchMajor"
+    }
+}

--- a/bucket/oraclejdk11.json
+++ b/bucket/oraclejdk11.json
@@ -1,0 +1,37 @@
+{
+    "description": "Oracle JDK 11",
+    "homepage": "https://www.oracle.com/technetwork/java/javase/overview/index.html",
+    "version": "11.0.2-9",
+    "license": "https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html",
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.huaweicloud.com/java/jdk/11.0.2+9/jdk-11.0.2_windows-x64_bin.zip",
+            "hash": "f38976b64633920ed27821fbd80ca924ce55d51b88f4de1933cacc8beecc5a60"
+        }
+    },
+    "cookie": {
+        "oraclelicense": "accept-securebackup-cookie"
+    },
+    "extract_dir": "jdk-11.0.2",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html",
+        "re": "otn-pub/java/jdk/(?<path>(?<major>[\\d.]+)\\+(?<build>[\\d]+)/(?<hash>[a-fA-F0-9]{32})/jdk-(?:.*?)_windows-x64_bin.zip)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$matchPath"
+            }
+        },
+        "hash": {
+            "url": "https://www.oracle.com/technetwork/java/javase/downloads/jdk11-downloads-5066655.html",
+            "find": "$basename.*([a-fA-F0-9]{64})\"};"
+        },
+        "extract_dir": "jdk-$matchMajor"
+    }
+}

--- a/bucket/oraclejdk17.json
+++ b/bucket/oraclejdk17.json
@@ -1,0 +1,37 @@
+{
+    "description": "Oracle JDK 17",
+    "homepage": "https://www.oracle.com/technetwork/java/javase/overview/index.html",
+    "version": "17.0.1",
+    "license": "https://www.oracle.com/technetwork/java/javase/terms/license/javase-license.html",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.oracle.com/java/17/archive/jdk-17.0.1_windows-x64_bin.zip",
+            "hash": "97b2db1db24a26a029e58af95260e7bd8226accf4095b7326b7d1b41de5b5bbb"
+        }
+    },
+    "cookie": {
+        "oraclelicense": "accept-securebackup-cookie"
+    },
+    "extract_dir": "jdk-17.0.1",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html",
+        "re": "otn-pub/java/jdk/(?<path>(?<major>[\\d.]+)\\+(?<build>[\\d]+)/(?<hash>[a-fA-F0-9]{32})/jdk-(?:.*?)_windows-x64_bin.zip)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$matchPath"
+            }
+        },
+        "hash": {
+            "url": "https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html",
+            "find": "$basename.*([a-fA-F0-9]{64})\"};"
+        },
+        "extract_dir": "jdk-$matchMajor"
+    }
+}

--- a/bucket/oraclejdk8.json
+++ b/bucket/oraclejdk8.json
@@ -1,0 +1,63 @@
+{
+    "description": "Oracle JDK 8",
+    "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
+    "version": "8u201-b09",
+    "license": "http://www.oracle.com/technetwork/java/javase/terms/license",
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.huaweicloud.com/java/jdk/8u201-b09/jdk-8u201-windows-x64.exe#/dl.7z",
+            "hash": "bf43f92ab22419a10878638c4fcd559085398233bce6427a89309cab850aab78"
+        },
+        "32bit": {
+            "url": "https://repo.huaweicloud.com/java/jdk/8u201-b09/jdk-8u201-windows-i586.exe#/dl.7z",
+            "hash": "c95830b3e78f5abae26d693d6fb0c16a229f14597f8216b919810b59ad7f752c"
+        }
+    },
+    "cookie": {
+        "oraclelicense": "accept-securebackup-cookie"
+    },
+    "extract_to": "tmp",
+    "installer": {
+        "script": [
+            "# Java Source (src.zip)",
+            "extract_7zip \"$dir\\tmp\\.rsrc\\1033\\JAVA_CAB9\\110\" \"$dir\"",
+            "# JDK (tools.zip)",
+            "extract_7zip \"$dir\\tmp\\.rsrc\\1033\\JAVA_CAB10\\111\" \"$dir\\tmp\"",
+            "extract_7zip \"$dir\\tmp\\tools.zip\" \"$dir\"",
+            "# Copyright (COPYRIGHT)",
+            "extract_7zip \"$dir\\tmp\\.rsrc\\1033\\JAVA_CAB11\\112\" \"$dir\"",
+            "# Convert .pack to .jar, and remove .pack",
+            "pushd \"$dir\"",
+            "ls \"$dir\" -recurse | ? name -match '^[^_].*?\\.(?i)pack$' | % {",
+            "    $name = $_.fullname -replace '\\.(?i)pack$', ''",
+            "    $pack = \"$name.pack\"",
+            "    $jar = \"$name.jar\"",
+            "    & \"bin\\unpack200.exe\" \"-r\" \"$pack\" \"$jar\"",
+            "}",
+            "rm -r tmp | out-null",
+            "popd"
+        ]
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+        "re": "(?<version>[ub\\-\\d]+)/(?<random>[a-fA-F0-9]{32})/jdk-(?<short>[u\\d]+)-windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-x64.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-i586.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+            "find": "$basename.*([a-fA-F0-9]{64})\"};"
+        }
+    }
+}

--- a/bucket/oraclejdk8u.json
+++ b/bucket/oraclejdk8u.json
@@ -1,0 +1,64 @@
+{
+    "description": "Oracle JDK 8 (PSU)",
+    "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
+    "version": "8u202-b08",
+    "license": "http://www.oracle.com/technetwork/java/javase/terms/license",
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.huaweicloud.com/java/jdk/8u202-b08/jdk-8u202-windows-x64.exe#/dl.7z",
+            "hash": "b3bcdd6007e30c7b9d459b5bef766ac49f1e0b1cc92b11b19af3cf0439c3bc9f"
+        },
+        "32bit": {
+            "url": "https://repo.huaweicloud.com/java/jdk/8u202-b08/jdk-8u202-windows-i586.exe#/dl.7z",
+            "hash": "88d6f861cc57866bfe85889798f18e0a0771ec0283ed81f3288049eb98d7c285"
+        }
+    },
+    "cookie": {
+        "oraclelicense": "accept-securebackup-cookie"
+    },
+    "extract_to": "tmp",
+    "installer": {
+        "script": [
+            "# Java Source (src.zip)",
+            "extract_7zip \"$dir\\tmp\\.rsrc\\1033\\JAVA_CAB9\\110\" \"$dir\"",
+            "# JDK (tools.zip)",
+            "extract_7zip \"$dir\\tmp\\.rsrc\\1033\\JAVA_CAB10\\111\" \"$dir\\tmp\"",
+            "extract_7zip \"$dir\\tmp\\tools.zip\" \"$dir\"",
+            "# Copyright (COPYRIGHT)",
+            "extract_7zip \"$dir\\tmp\\.rsrc\\1033\\JAVA_CAB11\\112\" \"$dir\"",
+            "# Convert .pack to .jar, and remove .pack",
+            "pushd \"$dir\"",
+            "ls \"$dir\" -recurse | ? name -match '^[^_].*?\\.(?i)pack$' | % {",
+            "    $name = $_.fullname -replace '\\.(?i)pack$', ''",
+            "    $pack = \"$name.pack\"",
+            "    $jar = \"$name.jar\"",
+            "    & \"bin\\unpack200.exe\" \"-r\" \"$pack\" \"$jar\"",
+            "}",
+            "rm -r tmp | out-null",
+            "popd"
+        ]
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+        "re": "(?<version>[ub\\-\\d]+)/(?<random>[a-fA-F0-9]{32})/jdk-(?<short>[u\\d]+)-windows",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://repo.huaweicloud.com/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-x64.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://repo.huaweicloud.com/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-i586.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+            "find": "$basename.*([a-fA-F0-9]{64})\"};"
+        }
+    }
+}


### PR DESCRIPTION
Recover scoop OracleJDK 8,11,17 ! Since Oracle's official download of the old version of the JDK requires identity authentication, I tried to replace it with the Huawei Cloud JDK address. Because the HASH of the installation package is consistent with the official, the mirror installation package is still reliable. Unfortunately, the mirror station cannot continue to be updated, only oraclejdk can be updated to 8u201,11.02. oraclejdk17 can be downloaded from the official without authentication. Please agree to my push Thank you!