### PR TITLE
Fix zulu11's hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+.idea
+.DS_Store

--- a/bucket/zulu11-jdk.json
+++ b/bucket/zulu11-jdk.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cdn.azul.com/zulu/bin/zulu11.54.25-ca-jdk11.0.14.1-win_x64.zip",
-            "hash": "727729a0a66d488664beabf28afecc122ea131a9ea2d3b628fc89a9878d7d32d",
+            "hash": "5ec3687f4e881d776376e9126e7484e9fed7a16865b40dfe9aa63d030219358f",
             "extract_dir": "zulu11.54.25-ca-jdk11.0.14.1-win_x64"
         },
         "32bit": {


### PR DESCRIPTION
```powershell
❯ scoop upgrade
zulu11-jdk: 11.54.23 -> 11.54.25
Updating one outdated app:
Updating 'zulu11-jdk' (11.54.23 -> 11.54.25)
Downloading new version
zulu11.54.25-ca-jdk11.0.14.1-win_x64.zip (187.7 MB) [=========================================================] 100%
Checking hash of zulu11.54.25-ca-jdk11.0.14.1-win_x64.zip ... ERROR Hash check failed!
App:         java/zulu11-jdk
URL:         https://cdn.azul.com/zulu/bin/zulu11.54.25-ca-jdk11.0.14.1-win_x64.zip
First bytes: 50 4B 03 04 0A 00 00 00
Expected:    727729a0a66d488664beabf28afecc122ea131a9ea2d3b628fc89a9878d7d32d
Actual:      5ec3687f4e881d776376e9126e7484e9fed7a16865b40dfe9aa63d030219358f

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/ScoopInstaller/Java/issues/new?title=zulu11-jdk%4011.54.25%3a+hash+check+failed
```