### PR TITLE
openjdk: Update to version 18.0.1.1-2

### DIFF
--- a/bucket/openjdk.json
+++ b/bucket/openjdk.json
@@ -1,21 +1,21 @@
 {
     "description": "Official General-Availability Release of OpenJDK",
     "homepage": "https://jdk.java.net/",
-    "version": "17.0.2-8",
+    "version": "18.0.1.1-2",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_windows-x64_bin.zip",
-            "hash": "b2208206bda47f2e0c971a39e057a5ec32c40b503d71e486790cb728d926b615"
+            "url": "https://download.java.net/java/GA/jdk18.0.1.1/65ae32619e2f40f3a9af3af1851d6e19/2/GPL/openjdk-18.0.1.1_windows-x64_bin.zip",
+            "hash": "a970b922a05a7fc2b077c89bf96c74570f65695b2ba067dc81805107517d7fed"
         }
     },
-    "extract_dir": "jdk-17.0.2",
+    "extract_dir": "jdk-18.0.1.1",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/17/",
+        "url": "https://jdk.java.net/18/",
         "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },


### PR DESCRIPTION
Version 18 has appeared in GA list.
And version 17 has been superseded.
Closes #382