### PR TITLE
oraclejre8@8u321: update manifest following a url change

### DIFF
--- a/bucket/oraclejre8.json
+++ b/bucket/oraclejre8.json
@@ -24,7 +24,7 @@
             "$ver = json_path $page $.fields.json.latest8Version",
             "$secid = json_path $page $.fields.json.secID",
             "$win32 = [int](json_path $page $.fields.json.win_offline_bundle) + 1",
-            "$win64 = [int](json_path $page $.fields.json.win_x64_bundle) + 1",
+            "$win64 = [int](json_path $page $.fields.json.win_x64_bundle) + 2",
             "Write-Output \"$ver $win32 $win64 $secid\""
         ],
         "regex": "(?<long>(?<ver>[\\d.]+)_(?<build>[\\d]+)) (?<win32b>[\\d]+) (?<win64b>[\\d]+) (?<secid>[\\da-f]{32})",


### PR DESCRIPTION
Value for win64 tar changed from one which blocked the checkver.
It should auto-update automatically (i tested on my computer), and it installed fine after.