### PR TITLE
[fix] microsoft-jdk: fix `extract_dir`

### DIFF
--- a/bucket/microsoft-jdk.json
+++ b/bucket/microsoft-jdk.json
@@ -9,7 +9,7 @@
             "hash": "be25ab2863f46e48f40a81d5471f63c558991eefd154a0a24c34818aaeade6c0"
         }
     },
-    "extract_dir": "jdk-17+0",
+    "extract_dir": "jdk-17.0.4+8",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"

--- a/bucket/microsoft-lts-jdk.json
+++ b/bucket/microsoft-lts-jdk.json
@@ -9,7 +9,7 @@
             "hash": "be25ab2863f46e48f40a81d5471f63c558991eefd154a0a24c34818aaeade6c0"
         }
     },
-    "extract_dir": "jdk-17+0",
+    "extract_dir": "jdk-17.0.4+8",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"

--- a/bucket/microsoft11-jdk.json
+++ b/bucket/microsoft11-jdk.json
@@ -9,7 +9,7 @@
             "hash": "511920c6ae93f3d197722c1c3b2a72ba2c0e2342fc5f9645773900aa6b0d591d"
         }
     },
-    "extract_dir": "jdk-11+0",
+    "extract_dir": "jdk-11.0.16+8",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"

--- a/bucket/microsoft17-jdk.json
+++ b/bucket/microsoft17-jdk.json
@@ -9,7 +9,7 @@
             "hash": "be25ab2863f46e48f40a81d5471f63c558991eefd154a0a24c34818aaeade6c0"
         }
     },
-    "extract_dir": "jdk-17+0",
+    "extract_dir": "jdk-17.0.4+8",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"


### PR DESCRIPTION
fixes #413, tested working
also fixes `microsoft-lts-jdk`, `microsoft11-jdk`, `microsoft17-jdk`