### PR TITLE
openjdk18: Persist cacerts file

### DIFF
--- a/bucket/openjdk18.json
+++ b/bucket/openjdk18.json
@@ -14,6 +14,7 @@
     "env_set": {
         "JAVA_HOME": "$dir"
     },
+    "persist": "lib/security/cacerts",
     "checkver": {
         "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"


### PR DESCRIPTION
When you add certificates to your trust store, they are lost after update because the `cacerts` file is not persisted.
This PR adds a `persist` section in `openjdk18` manifest so that cacerts are kept between updates.