### PR TITLE
oraclejdk-11: Add Version 11.0.16.1 LTS

### DIFF
--- a/bucket/oraclejdk-11
+++ b/bucket/oraclejdk-11
@@ -1,0 +1,33 @@
+{
+    "description": "Oracle Java Platform, Standard Edition Development Kit (JDK)",
+    "homepage": "https://www.oracle.com/java/technologies/downloads/#java11-windows",
+    "version": "11.0.16.1",
+    "license": "https://www.oracle.com/downloads/licenses/no-fee-license.html",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.oracle.com/java/11/archive/jdk-11.0.16.1_windows-x64_bin.zip",
+            "hash": "the url does not work"
+        }
+    },
+    "extract_dir": "jdk-11.0.16.1",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html",
+        "useragent": "curl/7",
+        "regex": "/jdk-([\\d.]+)_windows-x64"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.oracle.com/java/$majorVersion/archive/jdk-$version_windows-x64_bin.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        },
+        "extract_dir": "jdk-$version"
+    }
+}


### PR DESCRIPTION
Oracle **LTS** Java SE subscribers will receive JDK 11 updates until at least September of 2026.

I modified it from https://github.com/ScoopInstaller/Java/blob/master/bucket/oraclejdk-lts.json

https://github.com/ScoopInstaller/Java/issues/257#issuecomment-813879128

But I #NeedHelp with the download link