### PR TITLE
graalvm: Update GraalVM to JDK 19

### DIFF
--- a/bucket/graalvm.json
+++ b/bucket/graalvm.json
@@ -3,9 +3,9 @@
     "version": "22.3.0",
     "homepage": "https://www.graalvm.org/",
     "license": "GPL-2.0",
-    "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java17-windows-amd64-22.3.0.zip",
-    "hash": "5a6f1d640034166a0fefd9d8924c12b040f120cd019b46b40895ccc8e9a9fc9e",
-    "extract_dir": "graalvm-ce-java17-22.3.0",
+    "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java19-windows-amd64-22.3.0.zip",
+    "hash": "7ac4e89591bfac5f0651e45d2947cbaf795e43ab39152f65ad2bfdfb4a709482",
+    "extract_dir": "graalvm-ce-java19-22.3.0",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir",
@@ -16,8 +16,8 @@
         "regex": "vm-([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$version/graalvm-ce-java17-windows-amd64-$version.zip",
-        "extract_dir": "graalvm-ce-java17-$version",
+        "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$version/graalvm-ce-java19-windows-amd64-$version.zip",
+        "extract_dir": "graalvm-ce-java19-$version",
         "hash": {
             "url": "$url.sha256"
         }


### PR DESCRIPTION
Since we do have a graalvm-jdk17.json, I thought this would be more appropriate than creating a new file.