### PR TITLE
chore: Remove .gitkeep

### DIFF
--- a/bucket/.gitkeep
+++ b/bucket/.gitkeep
@@ -1,2 +1,0 @@
-# This directory stores all the JSON manifests.
-# Delete this '.gitkeep' file once this directory has any files.


### PR DESCRIPTION
Removes the .gitkeep file that should not be there, as indicated by the contents which state, "Delete this '.gitkeep' file once this directory has any files"

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
