### PR TITLE
openjdk-ea: Update to version 21-2-ea

### DIFF
--- a/bucket/openjdk-ea.json
+++ b/bucket/openjdk-ea.json
@@ -1,5 +1,5 @@
 {
-    "description": "Official production-ready open-source builds of OpenJDK 21",
+    "description": "Official Early-Access Builds of OpenJDK",
     "homepage": "https://jdk.java.net/",
     "version": "21-2-ea",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",

--- a/bucket/openjdk20.json
+++ b/bucket/openjdk20.json
@@ -15,6 +15,7 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
+        "url": "https://jdk.java.net/20",
         "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },

--- a/bucket/openjdk21.json
+++ b/bucket/openjdk21.json
@@ -1,6 +1,6 @@
 {
     "description": "Official production-ready open-source builds of OpenJDK 21",
-    "homepage": "https://jdk.java.net/",
+    "homepage": "https://jdk.java.net/21",
     "version": "21-2-ea",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Update `openjdk-ea` to version `21-2-ea`.
Added `openjdk21.json`.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
