### PR TITLE
intellij-jbr*: hashes fix. Now sha512

### DIFF
--- a/bucket/intellij-jbr11-jcef.json
+++ b/bucket/intellij-jbr11-jcef.json
@@ -25,7 +25,7 @@
                 "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
-                    "regex": "$sha256\\s"
+                    "regex": "$sha512\\s"
                 }
             }
         }

--- a/bucket/intellij-jbr11-sdk-jcef.json
+++ b/bucket/intellij-jbr11-sdk-jcef.json
@@ -25,7 +25,7 @@
                 "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
-                    "regex": "$sha256\\s"
+                    "regex": "$sha512\\s"
                 }
             }
         }

--- a/bucket/intellij-jbr11-sdk.json
+++ b/bucket/intellij-jbr11-sdk.json
@@ -35,7 +35,7 @@
         },
         "hash": {
             "url": "$url.checksum",
-            "regex": "$sha256\\s"
+            "regex": "$sha512\\s"
         }
     }
 }

--- a/bucket/intellij-jbr11.json
+++ b/bucket/intellij-jbr11.json
@@ -34,7 +34,7 @@
         },
         "hash": {
             "url": "$url.checksum",
-            "regex": "$sha256\\s"
+            "regex": "$sha512\\s"
         }
     }
 }

--- a/bucket/intellij-jbr17-jcef.json
+++ b/bucket/intellij-jbr17-jcef.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b469.82.tar.gz",
-            "hash": "369b69aef022ae8b02850ec29f1428e0f7600a8dbaabbb4cc5534d4779eff9e5",
+            "hash": "sha512:bddcb212a8aa3cb08f481e0d2ca2b44692484aea904e663ec02926546201c756369b69aef022ae8b02850ec29f1428e0f7600a8dbaabbb4cc5534d4779eff9e5",
             "extract_dir": "jbr_jcef-17.0.6-windows-x64-b469.82"
         }
     },
@@ -25,7 +25,7 @@
                 "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
-                    "regex": "$sha256\\s"
+                    "regex": "$sha512\\s"
                 },
                 "extract_dir": "jbr_jcef-$matchVersion-windows-x64-$matchBuild.$matchPatch"
             }

--- a/bucket/intellij-jbr17-sdk-jcef.json
+++ b/bucket/intellij-jbr17-sdk-jcef.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-17.0.6-windows-x64-b469.82.tar.gz",
-            "hash": "856180e7df816ffccca005e90c23d8098c7f7d70aaffb8ced4a055bb0883004f",
+            "hash": "sha512:83c3b718ffdfd3c7374b380befb111fe66f0ad0b8ded76253fb485cfaba60430856180e7df816ffccca005e90c23d8098c7f7d70aaffb8ced4a055bb0883004f",
             "extract_dir": "jbrsdk_jcef-17.0.6-windows-x64-b469.82"
         }
     },
@@ -25,7 +25,7 @@
                 "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
-                    "regex": "$sha256\\s"
+                    "regex": "$sha512\\s"
                 },
                 "extract_dir": "jbrsdk_jcef-$matchVersion-windows-x64-$matchBuild.$matchPatch"
             }

--- a/bucket/intellij-jbr17-sdk.json
+++ b/bucket/intellij-jbr17-sdk.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-windows-x64-b469.82.tar.gz",
-            "hash": "2c8a81b93a0faa248a4c3cbc441e0c67f3341087771a14d19364e282528a41b9",
+            "hash": "sha512:48dc0fbb2b18265f9fbf3041549eb19a761177700bc11ff61c4f1603cd311f442c8a81b93a0faa248a4c3cbc441e0c67f3341087771a14d19364e282528a41b9",
             "extract_dir": "jbrsdk-17.0.6-windows-x64-b469.82"
         }
     },
@@ -25,7 +25,7 @@
                 "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
-                    "regex": "$sha256\\s"
+                    "regex": "$sha512\\s"
                 },
                 "extract_dir": "jbrsdk-$matchVersion-windows-x64-$matchBuild.$matchPatch"
             }

--- a/bucket/intellij-jbr17.json
+++ b/bucket/intellij-jbr17.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-17.0.6-windows-x64-b469.82.tar.gz",
-            "hash": "1824db292cf814a2447f1e1640b4087dea5d6b7eff3c702fd3c30032708bebed",
+            "hash": "sha512:203385209c3276469f7adf871a7953d27dc0899f305bd5ec458c613a5bd33ee11824db292cf814a2447f1e1640b4087dea5d6b7eff3c702fd3c30032708bebed",
             "extract_dir": "jbr-17.0.6-windows-x64-b469.82"
         }
     },
@@ -25,7 +25,7 @@
                 "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
-                    "regex": "$sha256\\s"
+                    "regex": "$sha512\\s"
                 },
                 "extract_dir": "jbr-$matchVersion-windows-x64-$matchBuild.$matchPatch"
             }


### PR DESCRIPTION
Fixes jbr hashes. They are using sha512 now

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
