### PR TITLE
openjdk@21-35: fixed issue with unzipping folders

### DIFF
--- a/bucket/openjdk.json
+++ b/bucket/openjdk.json
@@ -9,7 +9,12 @@
             "hash": "5434faaf029e66e7ce6e75770ca384de476750984a7d2881ef7686894c4b4944"
         }
     },
-    "extract_dir": "jdk-20.0.2",
+    "installer": {
+        "script": [
+            "Move-Item \"$dir\\jdk-*\\*\" \"$dir\\\" -Force",
+            "Remove-Item \"$dir\\jdk-*\" -Force "
+        ]
+    },
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"

--- a/bucket/openjdk.json
+++ b/bucket/openjdk.json
@@ -9,12 +9,7 @@
             "hash": "5434faaf029e66e7ce6e75770ca384de476750984a7d2881ef7686894c4b4944"
         }
     },
-    "installer": {
-        "script": [
-            "Move-Item \"$dir\\jdk-*\\*\" \"$dir\\\" -Force",
-            "Remove-Item \"$dir\\jdk-*\" -Force "
-        ]
-    },
+    "extract_dir": "jdk-21",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"


### PR DESCRIPTION
Close #493
Openjdk.json will have problems during installation
![image](https://github.com/ScoopInstaller/Java/assets/143936289/e027d00c-f447-432b-b723-54b9b7b5025c)

I modified the openjdk.json file
![image](https://github.com/ScoopInstaller/Java/assets/143936289/3652a0e8-910f-4ae7-9360-ec1d9a756b47)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
