### PR TITLE
Added support for Corretto 20 and 21

### DIFF
--- a/bucket/corretto20-jdk.json
+++ b/bucket/corretto20-jdk.json
@@ -1,0 +1,34 @@
+{
+    "description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK)",
+    "homepage": "https://aws.amazon.com/corretto/",
+    "version": "20.0.2.10.1",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://corretto.aws/downloads/resources/20.0.2.10.1/amazon-corretto-20.0.2.10.1-windows-x64-jdk.zip",
+            "hash": "118e8258d5aa5c26a98778f11820c9910c677258152909636f3adfc2e5c93d4c"
+        }
+    },
+    "extract_dir": "jdk20.0.2_10",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
+        "jsonpath": "$.windows.x64.jdk.20.zip.resource",
+        "regex": "/([\\d.]+)/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://corretto.aws/downloads/resources/$version/amazon-corretto-$version-windows-x64-jdk.zip",
+                "hash": {
+                    "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
+                    "jsonpath": "$.windows.x64.jdk.20.zip.checksum_sha256"
+                }
+            }
+        },
+        "extract_dir": "jdk$matchHead_$buildVersion"
+    }
+}

--- a/bucket/corretto21-jdk.json
+++ b/bucket/corretto21-jdk.json
@@ -1,0 +1,34 @@
+{
+    "description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK)",
+    "homepage": "https://aws.amazon.com/corretto/",
+    "version": "21.0.1.12.1",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://corretto.aws/downloads/resources/21.0.1.12.1/amazon-corretto-21.0.1.12.1-windows-x64-jdk.zip",
+            "hash": "9f13477c8209ec5e2d59d728503fb61f0c2ee8765431ea542d721cb60b9061a8"
+        }
+    },
+    "extract_dir": "jdk21.0.1_12",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
+        "jsonpath": "$.windows.x64.jdk.21.zip.resource",
+        "regex": "/([\\d.]+)/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://corretto.aws/downloads/resources/$version/amazon-corretto-$version-windows-x64-jdk.zip",
+                "hash": {
+                    "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
+                    "jsonpath": "$.windows.x64.jdk.21.zip.checksum_sha256"
+                }
+            }
+        },
+        "extract_dir": "jdk$matchHead_$buildVersion"
+    }
+}


### PR DESCRIPTION
Noticed that Corretto 20 and 21 has no manifest, while Java 21 released recently. 

Used the corretto19-jdk.json as a template for 20 and 21 and the official resources for the version checking and hash. 

Local installation indicate the correct JDKs were installed, IntelliJ recognizes both.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).