### PR TITLE
graalvm-oracle-jdk: Add version 21.0.2 / 17.0.10

### DIFF
--- a/bucket/graalvm-oracle-17jdk.json
+++ b/bucket/graalvm-oracle-17jdk.json
@@ -1,0 +1,34 @@
+{
+    "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
+    "version": "17.0.10",
+    "homepage": "https://www.graalvm.org/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.oracle.com/downloads/licenses/graal-free-license.html"
+    },
+    "url": "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.10_windows-x64_bin.zip",
+    "hash": "1ab2291e71f54d73e3e57b7fccbf184cabcba37e16ca9d1cf42d08474a7c02f0",
+    "extract_to": "tmp",
+    "installer": {
+        "script": [
+            "(Get-ChildItem -Directory \"$dir\\tmp\").FullName | % { Move-Item \"$_\\*\" \"$dir\" }",
+            "Remove-Item -Recurse \"$dir\\tmp\""
+        ]
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/java/technologies/downloads/",
+        "useragent": "Mozilla/5.0",
+        "regex": "GraalVM for JDK ((?<ver>17)\\.[\\d.]+) downloads"
+    },
+    "autoupdate": {
+        "url": "https://download.oracle.com/graalvm/$matchVer/archive/graalvm-jdk-$version_windows-x64_bin.zip",
+        "hash": {
+            "url": "https://download.oracle.com/graalvm/$matchVer/archive/graalvm-jdk-$version_windows-x64_bin.zip.sha256"
+        }
+    }
+}

--- a/bucket/graalvm-oracle-21jdk.json
+++ b/bucket/graalvm-oracle-21jdk.json
@@ -1,0 +1,34 @@
+{
+    "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
+    "version": "21.0.2",
+    "homepage": "https://www.graalvm.org/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.oracle.com/downloads/licenses/graal-free-license.html"
+    },
+    "url": "https://download.oracle.com/graalvm/21/archive/graalvm-jdk-21.0.2_windows-x64_bin.zip",
+    "hash": "bc5027e506775813131509247424d4af839ad23224a7787b7770ae82eeb3b32d",
+    "extract_to": "tmp",
+    "installer": {
+        "script": [
+            "(Get-ChildItem -Directory \"$dir\\tmp\").FullName | % { Move-Item \"$_\\*\" \"$dir\" }",
+            "Remove-Item -Recurse \"$dir\\tmp\""
+        ]
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/java/technologies/downloads/",
+        "useragent": "Mozilla/5.0",
+        "regex": "GraalVM for JDK ((?<ver>21)\\.(?<build>[\\d.]+)) downloads"
+    },
+    "autoupdate": {
+        "url": "https://download.oracle.com/graalvm/$matchVer/archive/graalvm-jdk-$version_windows-x64_bin.zip",
+        "hash": {
+            "url": "https://download.oracle.com/graalvm/$matchVer/archive/graalvm-jdk-$version_windows-x64_bin.zip.sha256"
+        }
+    }
+}

--- a/bucket/graalvm-oracle-jdk.json
+++ b/bucket/graalvm-oracle-jdk.json
@@ -1,0 +1,34 @@
+{
+    "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
+    "version": "21.0.2",
+    "homepage": "https://www.graalvm.org/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.oracle.com/downloads/licenses/graal-free-license.html"
+    },
+    "url": "https://download.oracle.com/graalvm/21/archive/graalvm-jdk-21.0.2_windows-x64_bin.zip",
+    "hash": "bc5027e506775813131509247424d4af839ad23224a7787b7770ae82eeb3b32d",
+    "extract_to": "tmp",
+    "installer": {
+        "script": [
+            "(Get-ChildItem -Directory \"$dir\\tmp\").FullName | % { Move-Item \"$_\\*\" \"$dir\" }",
+            "Remove-Item -Recurse \"$dir\\tmp\""
+        ]
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/java/technologies/downloads/",
+        "useragent": "Mozilla/5.0",
+        "regex": "GraalVM for JDK ((?<ver>[\\d]*)\\.[\\d.]+) downloads"
+    },
+    "autoupdate": {
+        "url": "https://download.oracle.com/graalvm/$matchVer/archive/graalvm-jdk-$version_windows-x64_bin.zip",
+        "hash": {
+            "url": "https://download.oracle.com/graalvm/$matchVer/archive/graalvm-jdk-$version_windows-x64_bin.zip.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Relates to #472

JDK 20 is not in current releases now. I included 21 instead.
Since graalvm21-jdk21 got created recently, I didn't add/modify the ce one according to https://github.com/ScoopInstaller/Java/issues/472#issuecomment-1702439789 .

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
