### PR TITLE
graalvm-ce-jdk: add version 17.0.9 and 21.0.2

### DIFF
--- a/bucket/graalvm-ce-jdk17.json
+++ b/bucket/graalvm-ce-jdk17.json
@@ -1,0 +1,14 @@
+{
+    "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
+    "version": "17.0.9",
+    "homepage": "https://www.graalvm.org/",
+    "license": "GPL-2.0",
+    "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-17.0.9/graalvm-community-jdk-17.0.9_windows-x64_bin.zip",
+    "hash": "285e045bfc0b87d2b61958fea97444c3c6c7e68fba3fdbbe146622328b52ec38",
+    "extract_dir": "graalvm-community-openjdk-17.0.9",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
+    }
+}

--- a/bucket/graalvm-ce-jdk17.json
+++ b/bucket/graalvm-ce-jdk17.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0",
     "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-17.0.9/graalvm-community-jdk-17.0.9_windows-x64_bin.zip",
     "hash": "285e045bfc0b87d2b61958fea97444c3c6c7e68fba3fdbbe146622328b52ec38",
-    "extract_dir": "graalvm-community-openjdk-17.0.9",
+    "extract_dir": "graalvm-community-openjdk-17.0.9+9.1",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir",

--- a/bucket/graalvm-ce-jdk21.json
+++ b/bucket/graalvm-ce-jdk21.json
@@ -1,0 +1,14 @@
+{
+    "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
+    "version": "21.0.2",
+    "homepage": "https://www.graalvm.org/",
+    "license": "GPL-2.0",
+    "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_windows-x64_bin.zip",
+    "hash": "e17b7bead097bf372a5c75df17815b0a2f30b777a019d25eff7706b21421f7fa",
+    "extract_dir": "graalvm-community-openjdk-21.0.2",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
+    }
+}

--- a/bucket/graalvm-ce-jdk21.json
+++ b/bucket/graalvm-ce-jdk21.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0",
     "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_windows-x64_bin.zip",
     "hash": "e17b7bead097bf372a5c75df17815b0a2f30b777a019d25eff7706b21421f7fa",
-    "extract_dir": "graalvm-community-openjdk-21.0.2",
+    "extract_dir": "graalvm-community-openjdk-21.0.2+13.1",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir",


### PR DESCRIPTION
graalvm-ce-jdk: add version 17.0.9 and 21.0.2