### PR TITLE
openjdk: General-Availability to 23 and Early-Access to 24

### DIFF
--- a/bucket/openjdk-ea.json
+++ b/bucket/openjdk-ea.json
@@ -1,21 +1,21 @@
 {
     "description": "Official Early-Access Builds of OpenJDK",
     "homepage": "https://jdk.java.net/",
-    "version": "22.0.2-9",
+    "version": "24-ea",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://download.java.net/java/GA/jdk22.0.2/c9ecb94cd31b495da20a27d4581645e8/9/GPL/openjdk-22.0.2_windows-x64_bin.zip",
-            "hash": "f2a9b9ab944e71a64637fcdc6b13a1188cf02d4eb9ecf71dc927e98b3e45f5dc"
+            "url": "https://download.java.net/java/early_access/jdk24/18/GPL/openjdk-24-ea+18_windows-x64_bin.zip",
+            "hash": "6146921a840c402763aa710b209d872b2b91ba63221f33e494fa1312cb2a706c"
         }
     },
-    "extract_dir": "jdk-22.0.2",
+    "extract_dir": "jdk-24",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/22",
+        "url": "https://jdk.java.net/24",
         "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },

--- a/bucket/openjdk.json
+++ b/bucket/openjdk.json
@@ -1,21 +1,21 @@
 {
     "description": "Official General-Availability Release of OpenJDK",
     "homepage": "https://jdk.java.net/",
-    "version": "21.0.2-13",
+    "version": "23",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_windows-x64_bin.zip",
-            "hash": "b6c17e747ae78cdd6de4d7532b3164b277daee97c007d3eaa2b39cca99882664"
+            "url": "https://download.java.net/java/GA/jdk23/3c5b90190c68498b986a97f276efd28a/37/GPL/openjdk-23_windows-x64_bin.zip",
+            "hash": "cba5013874ba50cae543c86fe6423453816c77281e2751a8a9a633d966f1dc04"
         }
     },
-    "extract_dir": "jdk-21.0.2",
+    "extract_dir": "jdk-23",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/21/",
+        "url": "https://jdk.java.net/23",
         "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },

--- a/bucket/openjdk23.json
+++ b/bucket/openjdk23.json
@@ -1,0 +1,33 @@
+{
+  "description": "Official production-ready open-source builds of OpenJDK 23",
+  "homepage": "https://jdk.java.net/23",
+  "version": "23",
+  "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+  "architecture": {
+      "64bit": {
+          "url": "https://download.java.net/java/GA/jdk23/3c5b90190c68498b986a97f276efd28a/37/GPL/openjdk-23_windows-x64_bin.zip",
+          "hash": "cba5013874ba50cae543c86fe6423453816c77281e2751a8a9a633d966f1dc04"
+      }
+  },
+  "extract_dir": "jdk-23",
+  "env_add_path": "bin",
+  "env_set": {
+      "JAVA_HOME": "$dir"
+  },
+  "checkver": {
+      "url": "https://jdk.java.net/23",
+      "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
+      "replace": "${version}-${build}${ea}"
+  },
+  "autoupdate": {
+      "architecture": {
+          "64bit": {
+              "url": "https://download.java.net/java/$matchType/$matchPath/$matchFile"
+          }
+      },
+      "hash": {
+          "url": "$url.sha256"
+      },
+      "extract_dir": "jdk-$matchVersion"
+  }
+}


### PR DESCRIPTION
openjdk: General-Availability to 23 and Early-Access to 24

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
