### PR TITLE
added support for corretto 22 and 23

### DIFF
--- a/bucket/corretto22-jdk.json
+++ b/bucket/corretto22-jdk.json
@@ -1,0 +1,34 @@
+{
+    "description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK)",
+    "homepage": "https://aws.amazon.com/corretto/",
+    "version": "22.0.2.9.1",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://corretto.aws/downloads/resources/22.0.2.9.1/amazon-corretto-22.0.2.9.1-windows-x64-jdk.zip",
+            "hash": "c510db7c8de7b68a8ff73d01fd2293edfb82baed3ab1e1150509c46191de903c"
+        }
+    },
+    "extract_dir": "jdk22.0.2_9",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
+        "jsonpath": "$.windows.x64.jdk.22.zip.resource",
+        "regex": "/([\\d.]+)/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://corretto.aws/downloads/resources/$version/amazon-corretto-$version-windows-x64-jdk.zip",
+                "hash": {
+                    "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
+                    "jsonpath": "$.windows.x64.jdk.22.zip.checksum_sha256"
+                }
+            }
+        },
+        "extract_dir": "jdk$matchHead_$buildVersion"
+    }
+}

--- a/bucket/corretto23-jdk.json
+++ b/bucket/corretto23-jdk.json
@@ -1,0 +1,34 @@
+{
+    "description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK)",
+    "homepage": "https://aws.amazon.com/corretto/",
+    "version": "23.0.1.8.1",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://corretto.aws/downloads/resources/23.0.1.8.1/amazon-corretto-23.0.1.8.1-windows-x64-jdk.zip",
+            "hash": "bb592c042f19b0a3379221ed95e2f19a292bc8e584beff0c00e96bedd7e537a7"
+        }
+    },
+    "extract_dir": "jdk23.0.1_8",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
+        "jsonpath": "$.windows.x64.jdk.23.zip.resource",
+        "regex": "/([\\d.]+)/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://corretto.aws/downloads/resources/$version/amazon-corretto-$version-windows-x64-jdk.zip",
+                "hash": {
+                    "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
+                    "jsonpath": "$.windows.x64.jdk.23.zip.checksum_sha256"
+                }
+            }
+        },
+        "extract_dir": "jdk$matchHead_$buildVersion"
+    }
+}


### PR DESCRIPTION
This PR adds support for installing and updating Amazon Corretto 22 and 23.

The install and update script is based on the Corretto 21 script