### PR TITLE
fix(liberica): Update to Java 25 and Replace 32-bit to ARM64

### DIFF
--- a/bucket/liberica-full-jdk.json
+++ b/bucket/liberica-full-jdk.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-full.zip",
-            "hash": "sha1:67a00176acdf29a5c338f253b6267e75156db2b1"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64-full.zip",
+            "hash": "e9e5d4600b592cb6e05c2b96e82caae6e2a84ca72b8bf4b8604adbc5b450a0f0"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-full.zip",
-            "hash": "sha1:d2f0f9f0403147812828c3b42a383c004b8a37a7"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64-full.zip",
+            "hash": "109f1d725468507b70c0a869e076ac23c7cefc5df8df52c286036650bf10a568"
         }
     },
-    "extract_dir": "jdk-21.0.8-full",
+    "extract_dir": "jdk-25-full",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-full.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor-full"
     }

--- a/bucket/liberica-full-jdk.json
+++ b/bucket/liberica-full-jdk.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64-full.zip",
-            "hash": "e9e5d4600b592cb6e05c2b96e82caae6e2a84ca72b8bf4b8604adbc5b450a0f0"
+            "hash": "sha1:1b5ed6a4f1285a5236efc7299fcb62ed8ed936cd"
         },
         "arm64": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64-full.zip",
-            "hash": "109f1d725468507b70c0a869e076ac23c7cefc5df8df52c286036650bf10a568"
+            "hash": "sha1:17173014d635f426c40f6cd7c6ffee034f351c71"
         }
     },
     "extract_dir": "jdk-25-full",
@@ -33,6 +33,10 @@
             "arm64": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor-full"
     }

--- a/bucket/liberica-full-jre.json
+++ b/bucket/liberica-full-jre.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64-full.zip",
-            "hash": "sha1:d96a8d171da38505eba831fb7ea83bc79f63255c"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-amd64-full.zip",
+            "hash": "sha1:e7be82c6dcba6051b563150c107ef96b8fd5e0e4"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586-full.zip",
-            "hash": "sha1:54f084a4eec60ac6a57c8e42b0e882d3034e4fea"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-aarch64-full.zip",
+            "hash": "sha1:69224a1176f0dd70924e8b4b1f5df5e1ec1dd5b7"
         }
     },
-    "extract_dir": "jre-21.0.8-full",
+    "extract_dir": "jre-25-full",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64-full.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jre-$matchMajor-full"
     }

--- a/bucket/liberica-full-jre.json
+++ b/bucket/liberica-full-jre.json
@@ -34,6 +34,10 @@
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
         },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
         "extract_dir": "jre-$matchMajor-full"
     }
 }

--- a/bucket/liberica-full-lts-jdk.json
+++ b/bucket/liberica-full-lts-jdk.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-full.zip",
-            "hash": "sha1:67a00176acdf29a5c338f253b6267e75156db2b1"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64-full.zip",
+            "hash": "e9e5d4600b592cb6e05c2b96e82caae6e2a84ca72b8bf4b8604adbc5b450a0f0"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-full.zip",
-            "hash": "sha1:d2f0f9f0403147812828c3b42a383c004b8a37a7"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64-full.zip",
+            "hash": "109f1d725468507b70c0a869e076ac23c7cefc5df8df52c286036650bf10a568"
         }
     },
-    "extract_dir": "jdk-21.0.8-full",
+    "extract_dir": "jdk-25-full",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-full.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor-full"
     }

--- a/bucket/liberica-full-lts-jdk.json
+++ b/bucket/liberica-full-lts-jdk.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64-full.zip",
-            "hash": "e9e5d4600b592cb6e05c2b96e82caae6e2a84ca72b8bf4b8604adbc5b450a0f0"
+            "hash": "sha1:1b5ed6a4f1285a5236efc7299fcb62ed8ed936cd"
         },
         "arm64": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64-full.zip",
-            "hash": "109f1d725468507b70c0a869e076ac23c7cefc5df8df52c286036650bf10a568"
+            "hash": "sha1:17173014d635f426c40f6cd7c6ffee034f351c71"
         }
     },
     "extract_dir": "jdk-25-full",
@@ -33,6 +33,10 @@
             "arm64": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor-full"
     }

--- a/bucket/liberica-full-lts-jre.json
+++ b/bucket/liberica-full-lts-jre.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64-full.zip",
-            "hash": "sha1:d96a8d171da38505eba831fb7ea83bc79f63255c"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-amd64-full.zip",
+            "hash": "9dbb418a1abc81edfa86398d87aa2d67e0ae33eaab99b87a0253bd689e295693"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586-full.zip",
-            "hash": "sha1:54f084a4eec60ac6a57c8e42b0e882d3034e4fea"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-aarch64-full.zip",
+            "hash": "f3304baf8097fca64424dfa699fafd8c825870bc1d2bf0348d212de35b1050b4"
         }
     },
-    "extract_dir": "jre-21.0.8-full",
+    "extract_dir": "jre-25-full",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64-full.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jre-$matchMajor-full"
     }

--- a/bucket/liberica-full-lts-jre.json
+++ b/bucket/liberica-full-lts-jre.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-amd64-full.zip",
-            "hash": "9dbb418a1abc81edfa86398d87aa2d67e0ae33eaab99b87a0253bd689e295693"
+            "hash": "sha1:e7be82c6dcba6051b563150c107ef96b8fd5e0e4"
         },
         "arm64": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-aarch64-full.zip",
-            "hash": "f3304baf8097fca64424dfa699fafd8c825870bc1d2bf0348d212de35b1050b4"
+            "hash": "sha1:69224a1176f0dd70924e8b4b1f5df5e1ec1dd5b7"
         }
     },
     "extract_dir": "jre-25-full",
@@ -33,6 +33,10 @@
             "arm64": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
         },
         "extract_dir": "jre-$matchMajor-full"
     }

--- a/bucket/liberica-jdk.json
+++ b/bucket/liberica-jdk.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64.zip",
-            "hash": "ea6afd12285d2218cc1b329dfc29c5fbb25fed5a8c4c8eeabe855d868eecb57b"
+            "hash": "sha1:7a62e1df0da604723115acfb3240a79cd1261771"
         },
         "arm64": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64.zip",
-            "hash": "242445adc0f2ff418c47668c31527c894e889d7d4b1748990abe481acab928bc"
+            "hash": "sha1:c5a2d7969623bf419f76b4b2556b505ca1b0b0a3"
         }
     },
     "extract_dir": "jdk-25",
@@ -33,6 +33,10 @@
             "arm64": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor"
     }

--- a/bucket/liberica-jdk.json
+++ b/bucket/liberica-jdk.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64.zip",
-            "hash": "sha1:35d0fe7f6141caebb256b9c0467da33002a6f0d9"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64.zip",
+            "hash": "ea6afd12285d2218cc1b329dfc29c5fbb25fed5a8c4c8eeabe855d868eecb57b"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586.zip",
-            "hash": "sha1:0e34000477f64d816b691f511f0b8ebe0747f7af"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64.zip",
+            "hash": "242445adc0f2ff418c47668c31527c894e889d7d4b1748990abe481acab928bc"
         }
     },
-    "extract_dir": "jdk-21.0.8",
+    "extract_dir": "jdk-25",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor"
     }

--- a/bucket/liberica-jre.json
+++ b/bucket/liberica-jre.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-amd64.zip",
-            "hash": "a780cd97637314816193df8d85242d813821ec3267e0b15c8b965301fd93de02"
+            "hash": "sha1:ce7aef3ef3f894962016bbbf2f32fed4eb96e0c5"
         },
         "arm64": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-aarch64.zip",
-            "hash": "73fbb6701daba202e04e854f091dd83946b9d8fbdd57db2b9b7dbdace5eeffcd"
+            "hash": "sha1:c46e09734fa94a26052271aff2279b9f47beedfa"
         }
     },
     "extract_dir": "jre-25",
@@ -33,6 +33,10 @@
             "arm64": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
         },
         "extract_dir": "jre-$matchMajor"
     }

--- a/bucket/liberica-jre.json
+++ b/bucket/liberica-jre.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64.zip",
-            "hash": "sha1:ef497a0e77eb86b1c659bc9074962c69e29b1551"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-amd64.zip",
+            "hash": "a780cd97637314816193df8d85242d813821ec3267e0b15c8b965301fd93de02"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586.zip",
-            "hash": "sha1:e6f37c813835f4b9724d245e96ec958f2ea6ad76"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-aarch64.zip",
+            "hash": "73fbb6701daba202e04e854f091dd83946b9d8fbdd57db2b9b7dbdace5eeffcd"
         }
     },
-    "extract_dir": "jre-21.0.8",
+    "extract_dir": "jre-25",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jre-$matchMajor"
     }

--- a/bucket/liberica-lite-jdk.json
+++ b/bucket/liberica-lite-jdk.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64-lite.zip",
-            "hash": "9eb32802a87abc162d22328b2056d13d31495e0a57cf63b9c3e5664f6cbca55b"
+            "hash": "sha1:e2fa9243793aa64acde285b6556a7d0f8b0559e0"
         },
         "arm64": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64-lite.zip",
-            "hash": "053c12132c5c87db6a523e5e581c9132709a9aa8a41c8c0ad5e50aabf0ad5d1b"
+            "hash": "sha1:69dccf53ac60783928c0e1293d639ea51f1a192d"
         }
     },
     "extract_dir": "jdk-25-lite",
@@ -33,6 +33,10 @@
             "arm64": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-lite.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor-lite"
     }

--- a/bucket/liberica-lite-jdk.json
+++ b/bucket/liberica-lite-jdk.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-lite.zip",
-            "hash": "sha1:e0f6edea160f835fbca004e8bad25d7273dfc90b"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64-lite.zip",
+            "hash": "9eb32802a87abc162d22328b2056d13d31495e0a57cf63b9c3e5664f6cbca55b"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-lite.zip",
-            "hash": "sha1:71c8cfed8fa08d0993cea336fc990c8b6432318f"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64-lite.zip",
+            "hash": "053c12132c5c87db6a523e5e581c9132709a9aa8a41c8c0ad5e50aabf0ad5d1b"
         }
     },
-    "extract_dir": "jdk-21.0.8-lite",
+    "extract_dir": "jdk-25-lite",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-lite.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-lite.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-lite.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor-lite"
     }

--- a/bucket/liberica-lite-lts-jdk.json
+++ b/bucket/liberica-lite-lts-jdk.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64-lite.zip",
-            "hash": "9eb32802a87abc162d22328b2056d13d31495e0a57cf63b9c3e5664f6cbca55b"
+            "hash": "sha1:e2fa9243793aa64acde285b6556a7d0f8b0559e0"
         },
         "arm64": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64-lite.zip",
-            "hash": "053c12132c5c87db6a523e5e581c9132709a9aa8a41c8c0ad5e50aabf0ad5d1b"
+            "hash": "sha1:69dccf53ac60783928c0e1293d639ea51f1a192d"
         }
     },
     "extract_dir": "jdk-25-lite",
@@ -33,6 +33,10 @@
             "arm64": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-lite.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor-lite"
     }

--- a/bucket/liberica-lite-lts-jdk.json
+++ b/bucket/liberica-lite-lts-jdk.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-lite.zip",
-            "hash": "sha1:e0f6edea160f835fbca004e8bad25d7273dfc90b"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64-lite.zip",
+            "hash": "9eb32802a87abc162d22328b2056d13d31495e0a57cf63b9c3e5664f6cbca55b"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-lite.zip",
-            "hash": "sha1:71c8cfed8fa08d0993cea336fc990c8b6432318f"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64-lite.zip",
+            "hash": "053c12132c5c87db6a523e5e581c9132709a9aa8a41c8c0ad5e50aabf0ad5d1b"
         }
     },
-    "extract_dir": "jdk-21.0.8-lite",
+    "extract_dir": "jdk-25-lite",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-lite&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-lite.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-lite.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-lite.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor-lite"
     }

--- a/bucket/liberica-lts-jdk.json
+++ b/bucket/liberica-lts-jdk.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64.zip",
-            "hash": "ea6afd12285d2218cc1b329dfc29c5fbb25fed5a8c4c8eeabe855d868eecb57b"
+            "hash": "sha1:7a62e1df0da604723115acfb3240a79cd1261771"
         },
         "arm64": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64.zip",
-            "hash": "242445adc0f2ff418c47668c31527c894e889d7d4b1748990abe481acab928bc"
+            "hash": "sha1:c5a2d7969623bf419f76b4b2556b505ca1b0b0a3"
         }
     },
     "extract_dir": "jdk-25",
@@ -33,6 +33,10 @@
             "arm64": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor"
     }

--- a/bucket/liberica-lts-jdk.json
+++ b/bucket/liberica-lts-jdk.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64.zip",
-            "hash": "sha1:35d0fe7f6141caebb256b9c0467da33002a6f0d9"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64.zip",
+            "hash": "ea6afd12285d2218cc1b329dfc29c5fbb25fed5a8c4c8eeabe855d868eecb57b"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586.zip",
-            "hash": "sha1:0e34000477f64d816b691f511f0b8ebe0747f7af"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64.zip",
+            "hash": "242445adc0f2ff418c47668c31527c894e889d7d4b1748990abe481acab928bc"
         }
     },
-    "extract_dir": "jdk-21.0.8",
+    "extract_dir": "jdk-25",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jdk-$matchMajor"
     }

--- a/bucket/liberica-lts-jre.json
+++ b/bucket/liberica-lts-jre.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-amd64.zip",
-            "hash": "a780cd97637314816193df8d85242d813821ec3267e0b15c8b965301fd93de02"
+            "hash": "sha1:ce7aef3ef3f894962016bbbf2f32fed4eb96e0c5"
         },
         "arm64": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-aarch64.zip",
-            "hash": "73fbb6701daba202e04e854f091dd83946b9d8fbdd57db2b9b7dbdace5eeffcd"
+            "hash": "sha1:c46e09734fa94a26052271aff2279b9f47beedfa"
         }
     },
     "extract_dir": "jre-25",
@@ -33,6 +33,10 @@
             "arm64": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
         },
         "extract_dir": "jre-$matchMajor"
     }

--- a/bucket/liberica-lts-jre.json
+++ b/bucket/liberica-lts-jre.json
@@ -1,19 +1,19 @@
 {
     "description": "BellSoft Liberica is a 100% open-source Java implementation",
     "homepage": "https://bell-sw.com/java",
-    "version": "21.0.8-12",
+    "version": "25-37",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64.zip",
-            "hash": "sha1:ef497a0e77eb86b1c659bc9074962c69e29b1551"
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-amd64.zip",
+            "hash": "a780cd97637314816193df8d85242d813821ec3267e0b15c8b965301fd93de02"
         },
-        "32bit": {
-            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586.zip",
-            "hash": "sha1:e6f37c813835f4b9724d245e96ec958f2ea6ad76"
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jre25%2B37-windows-aarch64.zip",
+            "hash": "73fbb6701daba202e04e854f091dd83946b9d8fbdd57db2b9b7dbdace5eeffcd"
         }
     },
-    "extract_dir": "jre-21.0.8",
+    "extract_dir": "jre-25",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -22,20 +22,17 @@
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
         "jsonpath": "$.version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
-        "replace": "${major}-${build}"
+        "replace": "${major}-${build}",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64.zip"
             },
-            "32bit": {
-                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586.zip"
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
-        },
-        "hash": {
-            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
-            "jsonpath": "$.sha1"
         },
         "extract_dir": "jre-$matchMajor"
     }

--- a/bucket/liberica21-full-jdk.json
+++ b/bucket/liberica21-full-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-full.zip",
+            "hash": "sha1:67a00176acdf29a5c338f253b6267e75156db2b1"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-full.zip",
+            "hash": "sha1:d2f0f9f0403147812828c3b42a383c004b8a37a7"
+        }
+    },
+    "extract_dir": "jdk-21.0.8-full",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-full.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor-full"
+    }
+}

--- a/bucket/liberica21-full-jdk.json
+++ b/bucket/liberica21-full-jdk.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-full.zip",
             "hash": "sha1:d2f0f9f0403147812828c3b42a383c004b8a37a7"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-aarch64-full.zip",
+            "hash": "sha1:117282a6344ac3ff239dff310d331405ea2576a7"
         }
     },
     "extract_dir": "jdk-21.0.8-full",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
         },
         "hash": {

--- a/bucket/liberica21-full-jre.json
+++ b/bucket/liberica21-full-jre.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586-full.zip",
             "hash": "sha1:54f084a4eec60ac6a57c8e42b0e882d3034e4fea"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-aarch64-full.zip",
+            "hash": "sha1:4158061ba406bc1450b3e26868b6d6a45710b8ec"
         }
     },
     "extract_dir": "jre-21.0.8-full",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
         },
         "hash": {

--- a/bucket/liberica21-full-jre.json
+++ b/bucket/liberica21-full-jre.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64-full.zip",
+            "hash": "sha1:d96a8d171da38505eba831fb7ea83bc79f63255c"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586-full.zip",
+            "hash": "sha1:54f084a4eec60ac6a57c8e42b0e882d3034e4fea"
+        }
+    },
+    "extract_dir": "jre-21.0.8-full",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64-full.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jre-$matchMajor-full"
+    }
+}

--- a/bucket/liberica21-full-lts-jdk.json
+++ b/bucket/liberica21-full-lts-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-full.zip",
+            "hash": "sha1:67a00176acdf29a5c338f253b6267e75156db2b1"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-full.zip",
+            "hash": "sha1:d2f0f9f0403147812828c3b42a383c004b8a37a7"
+        }
+    },
+    "extract_dir": "jdk-21.0.8-full",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-full.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor-full"
+    }
+}

--- a/bucket/liberica21-full-lts-jdk.json
+++ b/bucket/liberica21-full-lts-jdk.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-full.zip",
             "hash": "sha1:d2f0f9f0403147812828c3b42a383c004b8a37a7"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-aarch64-full.zip",
+            "hash": "sha1:117282a6344ac3ff239dff310d331405ea2576a7"
         }
     },
     "extract_dir": "jdk-21.0.8-full",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
         },
         "hash": {

--- a/bucket/liberica21-full-lts-jre.json
+++ b/bucket/liberica21-full-lts-jre.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64-full.zip",
+            "hash": "sha1:d96a8d171da38505eba831fb7ea83bc79f63255c"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586-full.zip",
+            "hash": "sha1:54f084a4eec60ac6a57c8e42b0e882d3034e4fea"
+        }
+    },
+    "extract_dir": "jre-21.0.8-full",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64-full.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jre-$matchMajor-full"
+    }
+}

--- a/bucket/liberica21-full-lts-jre.json
+++ b/bucket/liberica21-full-lts-jre.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586-full.zip",
             "hash": "sha1:54f084a4eec60ac6a57c8e42b0e882d3034e4fea"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-aarch64-full.zip",
+            "hash": "sha1:4158061ba406bc1450b3e26868b6d6a45710b8ec"
         }
     },
     "extract_dir": "jre-21.0.8-full",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
             }
         },
         "hash": {

--- a/bucket/liberica21-jdk.json
+++ b/bucket/liberica21-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64.zip",
+            "hash": "sha1:35d0fe7f6141caebb256b9c0467da33002a6f0d9"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586.zip",
+            "hash": "sha1:0e34000477f64d816b691f511f0b8ebe0747f7af"
+        }
+    },
+    "extract_dir": "jdk-21.0.8",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor"
+    }
+}

--- a/bucket/liberica21-jdk.json
+++ b/bucket/liberica21-jdk.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586.zip",
             "hash": "sha1:0e34000477f64d816b691f511f0b8ebe0747f7af"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-aarch64.zip",
+            "hash": "sha1:72f929cca6abb7f8f73f387a9b7b5c57dd891cbf"
         }
     },
     "extract_dir": "jdk-21.0.8",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
         },
         "hash": {

--- a/bucket/liberica21-jre.json
+++ b/bucket/liberica21-jre.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64.zip",
+            "hash": "sha1:ef497a0e77eb86b1c659bc9074962c69e29b1551"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586.zip",
+            "hash": "sha1:e6f37c813835f4b9724d245e96ec958f2ea6ad76"
+        }
+    },
+    "extract_dir": "jre-21.0.8",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jre-$matchMajor"
+    }
+}

--- a/bucket/liberica21-jre.json
+++ b/bucket/liberica21-jre.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586.zip",
             "hash": "sha1:e6f37c813835f4b9724d245e96ec958f2ea6ad76"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-aarch64.zip",
+            "hash": "sha1:9451e66b7350fdf07287c14983c70f1d4f49a06c"
         }
     },
     "extract_dir": "jre-21.0.8",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
         },
         "hash": {

--- a/bucket/liberica21-lite-jdk.json
+++ b/bucket/liberica21-lite-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-lite.zip",
+            "hash": "sha1:e0f6edea160f835fbca004e8bad25d7273dfc90b"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-lite.zip",
+            "hash": "sha1:71c8cfed8fa08d0993cea336fc990c8b6432318f"
+        }
+    },
+    "extract_dir": "jdk-21.0.8-lite",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-lite.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-lite.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor-lite"
+    }
+}

--- a/bucket/liberica21-lite-jdk.json
+++ b/bucket/liberica21-lite-jdk.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-lite.zip",
             "hash": "sha1:71c8cfed8fa08d0993cea336fc990c8b6432318f"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-aarch64-lite.zip",
+            "hash": "sha1:348e11207d318aebb14641d6951ae9d51e990d7a"
         }
     },
     "extract_dir": "jdk-21.0.8-lite",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-lite.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-lite.zip"
             }
         },
         "hash": {

--- a/bucket/liberica21-lite-lts-jdk.json
+++ b/bucket/liberica21-lite-lts-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-lite.zip",
+            "hash": "sha1:e0f6edea160f835fbca004e8bad25d7273dfc90b"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-lite.zip",
+            "hash": "sha1:71c8cfed8fa08d0993cea336fc990c8b6432318f"
+        }
+    },
+    "extract_dir": "jdk-21.0.8-lite",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-lite&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-lite.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-lite.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor-lite"
+    }
+}

--- a/bucket/liberica21-lite-lts-jdk.json
+++ b/bucket/liberica21-lite-lts-jdk.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-lite.zip",
             "hash": "sha1:71c8cfed8fa08d0993cea336fc990c8b6432318f"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-aarch64-lite.zip",
+            "hash": "sha1:348e11207d318aebb14641d6951ae9d51e990d7a"
         }
     },
     "extract_dir": "jdk-21.0.8-lite",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-lite.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-lite.zip"
             }
         },
         "hash": {

--- a/bucket/liberica21-lts-jdk.json
+++ b/bucket/liberica21-lts-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64.zip",
+            "hash": "sha1:35d0fe7f6141caebb256b9c0467da33002a6f0d9"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586.zip",
+            "hash": "sha1:0e34000477f64d816b691f511f0b8ebe0747f7af"
+        }
+    },
+    "extract_dir": "jdk-21.0.8",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor"
+    }
+}

--- a/bucket/liberica21-lts-jdk.json
+++ b/bucket/liberica21-lts-jdk.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586.zip",
             "hash": "sha1:0e34000477f64d816b691f511f0b8ebe0747f7af"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-aarch64.zip",
+            "hash": "sha1:72f929cca6abb7f8f73f387a9b7b5c57dd891cbf"
         }
     },
     "extract_dir": "jdk-21.0.8",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
         },
         "hash": {

--- a/bucket/liberica21-lts-jre.json
+++ b/bucket/liberica21-lts-jre.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64.zip",
+            "hash": "sha1:ef497a0e77eb86b1c659bc9074962c69e29b1551"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586.zip",
+            "hash": "sha1:e6f37c813835f4b9724d245e96ec958f2ea6ad76"
+        }
+    },
+    "extract_dir": "jre-21.0.8",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jre-$matchMajor"
+    }
+}

--- a/bucket/liberica21-lts-jre.json
+++ b/bucket/liberica21-lts-jre.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586.zip",
             "hash": "sha1:e6f37c813835f4b9724d245e96ec958f2ea6ad76"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-aarch64.zip",
+            "hash": "sha1:9451e66b7350fdf07287c14983c70f1d4f49a06c"
         }
     },
     "extract_dir": "jre-21.0.8",
@@ -31,6 +35,9 @@
             },
             "32bit": {
                 "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64.zip"
             }
         },
         "hash": {

--- a/bucket/liberica25-full-jdk.json
+++ b/bucket/liberica25-full-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "25-37",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-amd64-full.zip",
+            "hash": "sha1:1b5ed6a4f1285a5236efc7299fcb62ed8ed936cd"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/25%2B37/bellsoft-jdk25%2B37-windows-aarch64-full.zip",
+            "hash": "sha1:17173014d635f426c40f6cd7c6ffee034f351c71"
+        }
+    },
+    "extract_dir": "jdk-25-full",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-full.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor-full"
+    }
+}

--- a/bucket/liberica25-full-jre.json
+++ b/bucket/liberica25-full-jre.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64-full.zip",
+            "hash": "sha1:d96a8d171da38505eba831fb7ea83bc79f63255c"
+        },
+        "arm64": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-aarch64-full.zip",
+            "hash": "sha1:4158061ba406bc1450b3e26868b6d6a45710b8ec"
+        }
+    },
+    "extract_dir": "jre-21.0.8-full",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64-full.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-aarch64-full.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jre-$matchMajor-full"
+    }
+}

--- a/bucket/liberica25-full-lts-jdk.json
+++ b/bucket/liberica25-full-lts-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-full.zip",
+            "hash": "sha1:67a00176acdf29a5c338f253b6267e75156db2b1"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-full.zip",
+            "hash": "sha1:d2f0f9f0403147812828c3b42a383c004b8a37a7"
+        }
+    },
+    "extract_dir": "jdk-21.0.8-full",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-full.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor-full"
+    }
+}

--- a/bucket/liberica25-full-lts-jre.json
+++ b/bucket/liberica25-full-lts-jre.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64-full.zip",
+            "hash": "sha1:d96a8d171da38505eba831fb7ea83bc79f63255c"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586-full.zip",
+            "hash": "sha1:54f084a4eec60ac6a57c8e42b0e882d3034e4fea"
+        }
+    },
+    "extract_dir": "jre-21.0.8-full",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64-full.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586-full.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jre-$matchMajor-full"
+    }
+}

--- a/bucket/liberica25-jdk.json
+++ b/bucket/liberica25-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64.zip",
+            "hash": "sha1:35d0fe7f6141caebb256b9c0467da33002a6f0d9"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586.zip",
+            "hash": "sha1:0e34000477f64d816b691f511f0b8ebe0747f7af"
+        }
+    },
+    "extract_dir": "jdk-21.0.8",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor"
+    }
+}

--- a/bucket/liberica25-jre.json
+++ b/bucket/liberica25-jre.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64.zip",
+            "hash": "sha1:ef497a0e77eb86b1c659bc9074962c69e29b1551"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586.zip",
+            "hash": "sha1:e6f37c813835f4b9724d245e96ec958f2ea6ad76"
+        }
+    },
+    "extract_dir": "jre-21.0.8",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jre-$matchMajor"
+    }
+}

--- a/bucket/liberica25-lite-jdk.json
+++ b/bucket/liberica25-lite-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-lite.zip",
+            "hash": "sha1:e0f6edea160f835fbca004e8bad25d7273dfc90b"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-lite.zip",
+            "hash": "sha1:71c8cfed8fa08d0993cea336fc990c8b6432318f"
+        }
+    },
+    "extract_dir": "jdk-21.0.8-lite",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-lite.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-lite.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor-lite"
+    }
+}

--- a/bucket/liberica25-lite-lts-jdk.json
+++ b/bucket/liberica25-lite-lts-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64-lite.zip",
+            "hash": "sha1:e0f6edea160f835fbca004e8bad25d7273dfc90b"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586-lite.zip",
+            "hash": "sha1:71c8cfed8fa08d0993cea336fc990c8b6432318f"
+        }
+    },
+    "extract_dir": "jdk-21.0.8-lite",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-lite&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64-lite.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586-lite.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor-lite"
+    }
+}

--- a/bucket/liberica25-lts-jdk.json
+++ b/bucket/liberica25-lts-jdk.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-amd64.zip",
+            "hash": "sha1:35d0fe7f6141caebb256b9c0467da33002a6f0d9"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jdk21.0.8%2B12-windows-i586.zip",
+            "hash": "sha1:0e34000477f64d816b691f511f0b8ebe0747f7af"
+        }
+    },
+    "extract_dir": "jdk-21.0.8",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jdk$matchMajor%2B$matchBuild-windows-i586.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jdk-$matchMajor"
+    }
+}

--- a/bucket/liberica25-lts-jre.json
+++ b/bucket/liberica25-lts-jre.json
@@ -1,0 +1,42 @@
+{
+    "description": "BellSoft Liberica is a 100% open-source Java implementation",
+    "homepage": "https://bell-sw.com/java",
+    "version": "21.0.8-12",
+    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-amd64.zip",
+            "hash": "sha1:ef497a0e77eb86b1c659bc9074962c69e29b1551"
+        },
+        "32bit": {
+            "url": "https://github.com/bell-sw/Liberica/releases/download/21.0.8%2B12/bellsoft-jre21.0.8%2B12-windows-i586.zip",
+            "hash": "sha1:e6f37c813835f4b9724d245e96ec958f2ea6ad76"
+        }
+    },
+    "extract_dir": "jre-21.0.8",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
+        "jsonpath": "$.version",
+        "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
+        "replace": "${major}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bell-sw/Liberica/releases/download/$matchMajor%2B$matchBuild/bellsoft-jre$matchMajor%2B$matchBuild-windows-i586.zip"
+            }
+        },
+        "hash": {
+            "url": "https://api.bell-sw.com/v1/liberica/releases/$basename",
+            "jsonpath": "$.sha1"
+        },
+        "extract_dir": "jre-$matchMajor"
+    }
+}


### PR DESCRIPTION
Closes #556 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

This PR also includes many new Liberica packages for Java 21 and Java 25.