### PR TITLE
Create graalvm25.json

### DIFF
--- a/bucket/graalvm25.json
+++ b/bucket/graalvm25.json
@@ -1,0 +1,30 @@
+{
+    "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
+    "version": "25.0.0",
+    "homepage": "https://www.graalvm.org/",
+    "license": "GPL-2.0",
+    "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.0/graalvm-community-jdk-25.0.0_windows-x64_bin.zip",
+    "hash": "33ef1d186b5c1e95465fcc97e637bc26e72d5f2250a8615b9c5d667ed5c17fd0",
+    "extract_to": "tmp",
+    "installer": {
+        "script": [
+            "(Get-ChildItem -Directory \"$dir\\tmp\").FullName | % { Move-Item \"$_\\*\" \"$dir\" }",
+            "Remove-Item -Recurse \"$dir\\tmp\""
+        ]
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir",
+        "GRAALVM_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://github.com/graalvm/graalvm-ce-builds/releases/latest",
+        "regex": "jdk-(25[\\d.]*)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-$version/graalvm-community-jdk-$version_windows-x64_bin.zip",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Added installer of graalvm 25 - jdk25

Added the installer for graalvm 25 with JDK 25 to the Java bucket

There is yet another PR which aims to add the installer for Temurin 25, I'm just adding the installer for GraalVM 25

Note: I edited the installer of GraalVM 21, where the regex under checkver/version permits only versions with at least a minor spec. In this one I loosen a bit the check to allow versions without minor on the github release page

Relates to #561
Closes #562 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
