### PR TITLE
temurin-25: Make sure the manifests match those of previous LTS versions

### DIFF
--- a/bucket/temurin25-jdk.json
+++ b/bucket/temurin25-jdk.json
@@ -1,7 +1,7 @@
 {
     "description": "Eclipse Temurin is a runtime provided by Eclipse Adoptium for general use across the Java ecosystem",
     "homepage": "https://adoptium.net",
-    "version": "25.0.0-36.0.LTS",
+    "version": "25.0.0-36.0",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
@@ -17,7 +17,7 @@
     "checkver": {
         "url": "https://api.adoptium.net/v3/assets/feature_releases/25/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jdk&project=jdk&vendor=eclipse&page_size=1&sort_order=DESC",
         "script": [
-            "$ver = (json_path $page $..version_data.semver).replace('+', '-')",
+            "$ver = (json_path $page $..version_data.semver).replace('+', '-').replace('.LTS', '')",
             "$link = (json_path $page $..release_link).replace('%2B', '+')",
             "$name = json_path $page $..binaries[0].package.name",
             "Write-Output \"$ver $link $name\""
@@ -33,7 +33,7 @@
         },
         "hash": {
             "url": "$url.sha256.txt",
-            "regex": "^([a-fA-F0-9]+)\\s"
+            "find": "^([a-fA-F0-9]+)\\s"
         },
         "extract_dir": "$matchTag"
     }

--- a/bucket/temurin25-jre.json
+++ b/bucket/temurin25-jre.json
@@ -1,7 +1,7 @@
 {
     "description": "Eclipse Temurin is a runtime provided by Eclipse Adoptium for general use across the Java ecosystem",
     "homepage": "https://adoptium.net",
-    "version": "25.0.0-36.0.LTS",
+    "version": "25.0.0-36.0",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
@@ -17,7 +17,7 @@
     "checkver": {
         "url": "https://api.adoptium.net/v3/assets/feature_releases/25/ga?jvm_impl=hotspot&heap_size=normal&os=windows&architecture=x64&image_type=jre&project=jdk&vendor=eclipse&page_size=1&sort_order=DESC",
         "script": [
-            "$ver = (json_path $page $..version_data.semver).replace('+', '-')",
+            "$ver = (json_path $page $..version_data.semver).replace('+', '-').replace('.LTS', '')",
             "$link = (json_path $page $..release_link).replace('%2B', '+')",
             "$name = json_path $page $..binaries[0].package.name",
             "Write-Output \"$ver $link $name\""
@@ -33,7 +33,7 @@
         },
         "hash": {
             "url": "$url.sha256.txt",
-            "regex": "^([a-fA-F0-9]+)\\s"
+            "find": "^([a-fA-F0-9]+)\\s"
         },
         "extract_dir": "$matchTag-jre"
     }


### PR DESCRIPTION
The ".LTS" version suffix is removed for the other LTS manifests, so it should be removed for version 25 as well

Relates to #560

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected version display for Temurin 25 JDK/JRE by removing the “.LTS” suffix.

- Chores
  - Standardized version formatting for Temurin 25 JDK/JRE packages (e.g., 25.0.0-36.0).
  - Adjusted update checks and hash retrieval to align with the new version format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->