### PR TITLE
microsoft-lts-jdk: Update to Version 25.0.2

### DIFF
--- a/bucket/microsoft-lts-jdk.json
+++ b/bucket/microsoft-lts-jdk.json
@@ -1,16 +1,12 @@
 {
-    "description": "The Microsoft Build of OpenJDK is a no-cost long-term supported distribution and Microsoft's way to collaborate and contribute to the Java ecosystem.",
+    "description": "Microsoft Build of OpenJDK is a new no-cost long-term supported distribution",
     "homepage": "https://www.microsoft.com/openjdk/",
-    "version": "21.0.9",
+    "version": "25.0.1",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.9-windows-x64.zip",
-            "hash": "96cda27c4d2171b94125e2c7dedad3d22c8e02f99babfe3369ac52af06b4397a"
-        },
-        "arm64": {
-            "url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.9-windows-aarch64.zip",
-            "hash": "eb446c40cecd0e465bd6496d9a215b285330bf2515525749d870cb2c6799b3a4"
+            "url": "https://aka.ms/download-jdk/microsoft-jdk-25.0.1-windows-x64.msi",
+            "hash": "5ce322c00d8d56b99eeaec7abad6328f2b95f4d22e23558fc23b87464ff27597"
         }
     },
     "extract_to": "tmp",
@@ -26,15 +22,12 @@
     },
     "checkver": {
         "url": "https://docs.microsoft.com/java/openjdk/download",
-        "regex": "(?<ms>microsoft-jdk-((?<ver>21[\\d.]*?).(?<build>[\\d]+).[\\d]+)-windows-x64).zip"
+        "regex": "(?<ms>microsoft-jdk-((?<ver>25[\\d.]*?).(?<build>[\\d]+).[\\d]+)-windows-x64).msi"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://aka.ms/download-jdk/microsoft-jdk-$version-windows-x64.zip"
-            },
-            "arm64": {
-                "url": "https://aka.ms/download-jdk/microsoft-jdk-$version-windows-aarch64.zip"
+                "url": "https://aka.ms/download-jdk/microsoft-jdk-$version-windows-x64.msi"
             }
         },
         "hash": {

--- a/bucket/microsoft-lts-jdk.json
+++ b/bucket/microsoft-lts-jdk.json
@@ -1,7 +1,7 @@
 {
     "description": "Microsoft Build of OpenJDK is a new no-cost long-term supported distribution",
     "homepage": "https://www.microsoft.com/openjdk/",
-    "version": "25.0.1",
+    "version": "25.0.2",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {

--- a/bucket/microsoft-lts-jdk.json
+++ b/bucket/microsoft-lts-jdk.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-x64.zip",
-            "hash": "38d1a42d189c50b24152014ef131931f25f4cc80400ce618f0477f5e4e5aa252"              
+            "hash": "38d1a42d189c50b24152014ef131931f25f4cc80400ce618f0477f5e4e5aa252"
         },
         "arm64": {
             "url": "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-aarch64.zip",

--- a/bucket/microsoft-lts-jdk.json
+++ b/bucket/microsoft-lts-jdk.json
@@ -5,8 +5,12 @@
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://aka.ms/download-jdk/microsoft-jdk-25.0.1-windows-x64.msi",
-            "hash": "5ce322c00d8d56b99eeaec7abad6328f2b95f4d22e23558fc23b87464ff27597"
+            "url": "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-x64.zip",
+            "hash": "38d1a42d189c50b24152014ef131931f25f4cc80400ce618f0477f5e4e5aa252"              
+        },
+        "arm64": {
+            "url": "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-aarch64.zip",
+            "hash": "e0d9380cf3d0b5efc675664fa0db22cc9eb5d77c4fd2a132f4b58df0608593cf"
         }
     },
     "extract_to": "tmp",
@@ -21,13 +25,16 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://docs.microsoft.com/java/openjdk/download",
-        "regex": "(?<ms>microsoft-jdk-((?<ver>25[\\d.]*?).(?<build>[\\d]+).[\\d]+)-windows-x64).msi"
+        "url": "https://learn.microsoft.com/en-us/java/openjdk/download",
+        "regex": "(?<ms>microsoft-jdk-((?<ver>25[\\d.]*?).(?<build>[\\d]+).[\\d]+)-windows-x64).zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://aka.ms/download-jdk/microsoft-jdk-$version-windows-x64.msi"
+                "url": "https://aka.ms/download-jdk/microsoft-jdk-$version-windows-x64.zip"
+            },
+            "arm64": {
+                "url": "https://aka.ms/download-jdk/microsoft-jdk-$version-windows-aarch64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows installers now configure JAVA_HOME, add Java to PATH, and clean up temporary files after installation.

* **Chores**
  * Version bumped to 25.0.2.
  * Product description, download URLs, and version-detection sources updated to align with the 25.x release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->