### PR TITLE
`intellij-jbr25*`: add version 25.0.1-b266.34

### DIFF
--- a/bucket/intellij-jbr25-jcef.json
+++ b/bucket/intellij-jbr25-jcef.json
@@ -1,18 +1,18 @@
 {
-    "version": "25-b176.4",
+    "version": "25.0.1-b266.34",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
     "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25-windows-x64-b176.4.tar.gz",
-            "hash": "sha512:719fc61993152209beebc7901cbae59287c3716a761551391a1745c30b702db7b62d56797b33a04b011a285e1de189f454ba2ec9b3c282b959cb37390fd4ec38",
-            "extract_dir": "jbr_jcef-25-windows-x64-b176.4"
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25.0.1-windows-x64-b266.34.tar.gz",
+            "hash": "sha512:398460a721a452ec24776c5a2108e03842badf0f54c928e28196a976a683d2d25bc382ed9b317d8baac8623e3810b58db8f87b8a309c6e9a504ebfc20d444ec5",
+            "extract_dir": "jbr_jcef-25.0.1-windows-x64-b266.34"
         },
         "arm64": {
-            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25-windows-aarch64-b176.4.tar.gz",
-            "hash": "sha512:73ef9f8df213b2289cbaee46a4aa62a53bf6d0b0426fef5dcc68925cd8eb0e680bb9fa0b69345fd14670dbd917e7f2c92e79b357b28722e170777d970c514e57",
-            "extract_dir": "jbr_jcef-25-windows-aarch64-b176.4"
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25.0.1-windows-aarch64-b266.34.tar.gz",
+            "hash": "sha512:a1f6937bd89ed801a3e669735fa097d4216b2f5aaac4b28e220a74d186779b84fc049e60c2a1e30d9a68c171a4360413192a8de8709a3d89b30dc7e4f0df7882",
+            "extract_dir": "jbr_jcef-25.0.1-windows-aarch64-b266.34"
         }
     },
     "env_set": {
@@ -26,38 +26,41 @@
             "$tags = $releases | ForEach-Object { $_.tag_name }",
             "# `$Script:expected_ver` is current version for fallback",
             "$tags += 'jbr-release-' + ($Script:expected_ver -replace '-', '')",
-            "$pattern = 'jbr-release-25b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
+            "$pattern = 'jbr-release-25\\.(?<Version>[\\d.]+)b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
             "$matches = foreach ($t in $tags) { if ($t -match $pattern) {",
             "    [PSCustomObject]@{",
             "      Tag = $t",
+            "      VersionParts = ($Matches.Version -split '\\.') | ForEach-Object { [int]$_ }",
             "      BuildNum = [int]$Matches.BuildNum",
             "      Patch = [int]$Matches.Patch",
             "    }",
             "  } }",
-            "$latest = $matches | Sort-Object @{Expression={$_.BuildNum}},",
+            "$latest = $matches | Sort-Object @{Expression={$_.VersionParts[0]}},",
+            "                                 @{Expression={$_.VersionParts[1]}},",
+            "                                 @{Expression={$_.BuildNum}},",
             "                                 @{Expression={$_.Patch}} | Select-Object -Last 1",
             "Write-Output $latest.Tag"
         ],
-        "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
-        "replace": "25-${Build}.${Patch}"
+        "regex": "jbr-release-25\\.(?<Version>[\\d.]+)(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
+        "replace": "25.${Version}-${Build}.${Patch}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25-windows-x64-$matchBuild.$matchPatch.tar.gz",
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25.$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
                     "regex": "$sha512\\s"
                 },
-                "extract_dir": "jbr_jcef-25-windows-x64-$matchBuild.$matchPatch"
+                "extract_dir": "jbr_jcef-25.$matchVersion-windows-x64-$matchBuild.$matchPatch"
             },
             "arm64": {
-                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25.$matchVersion-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
                     "regex": "$sha512\\s"
                 },
-                "extract_dir": "jbr_jcef-25-windows-aarch64-$matchBuild.$matchPatch"
+                "extract_dir": "jbr_jcef-25.$matchVersion-windows-aarch64-$matchBuild.$matchPatch"
             }
         }
     }

--- a/bucket/intellij-jbr25-jcef.json
+++ b/bucket/intellij-jbr25-jcef.json
@@ -1,5 +1,5 @@
 {
-    "version": "25b176.4",
+    "version": "25-b176.4",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
     "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
@@ -39,7 +39,7 @@
             "Write-Output $latest.Tag"
         ],
         "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
-        "replace": "25${Build}.${Patch}"
+        "replace": "25-${Build}.${Patch}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/intellij-jbr25-jcef.json
+++ b/bucket/intellij-jbr25-jcef.json
@@ -1,0 +1,64 @@
+{
+    "version": "25b176.4",
+    "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
+    "description": "A fork of OpenJDK that includes a number enhancements in font rendering, HiDPI support, ligatures, performance improvements, and bugfixes. These are mainly for running IntelliJ Platform-based products",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25-windows-x64-b176.4.tar.gz",
+            "hash": "sha512:719fc61993152209beebc7901cbae59287c3716a761551391a1745c30b702db7b62d56797b33a04b011a285e1de189f454ba2ec9b3c282b959cb37390fd4ec38",
+            "extract_dir": "jbr_jcef-25-windows-x64-b176.4"
+        },
+        "arm64": {
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25-windows-aarch64-b176.4.tar.gz",
+            "hash": "sha512:73ef9f8df213b2289cbaee46a4aa62a53bf6d0b0426fef5dcc68925cd8eb0e680bb9fa0b69345fd14670dbd917e7f2c92e79b357b28722e170777d970c514e57",
+            "extract_dir": "jbr_jcef-25-windows-aarch64-b176.4"
+        }
+    },
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "env_add_path": "bin",
+    "checkver": {
+        "script": [
+            "$url = 'https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases'",
+            "$releases = Invoke-RestMethod $url",
+            "$tags = $releases | ForEach-Object { $_.tag_name }",
+            "# `$Script:expected_ver` is current version for fallback",
+            "$tags += 'jbr-release-' + ($Script:expected_ver -replace '-', '')",
+            "$pattern = 'jbr-release-25b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
+            "$matches = foreach ($t in $tags) { if ($t -match $pattern) {",
+            "    [PSCustomObject]@{",
+            "      Tag = $t",
+            "      BuildNum = [int]$Matches.BuildNum",
+            "      Patch = [int]$Matches.Patch",
+            "    }",
+            "  } }",
+            "$latest = $matches | Sort-Object @{Expression={$_.BuildNum}},",
+            "                                 @{Expression={$_.Patch}} | Select-Object -Last 1",
+            "Write-Output $latest.Tag"
+        ],
+        "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
+        "replace": "25${Build}.${Patch}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25-windows-x64-$matchBuild.$matchPatch.tar.gz",
+                "hash": {
+                    "url": "$url.checksum",
+                    "regex": "$sha512\\s"
+                },
+                "extract_dir": "jbr_jcef-25-windows-x64-$matchBuild.$matchPatch"
+            },
+            "arm64": {
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-25-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
+                "hash": {
+                    "url": "$url.checksum",
+                    "regex": "$sha512\\s"
+                },
+                "extract_dir": "jbr_jcef-25-windows-aarch64-$matchBuild.$matchPatch"
+            }
+        }
+    }
+}

--- a/bucket/intellij-jbr25-jcef.json
+++ b/bucket/intellij-jbr25-jcef.json
@@ -1,7 +1,7 @@
 {
     "version": "25b176.4",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
-    "description": "A fork of OpenJDK that includes a number enhancements in font rendering, HiDPI support, ligatures, performance improvements, and bugfixes. These are mainly for running IntelliJ Platform-based products",
+    "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {

--- a/bucket/intellij-jbr25-sdk-jcef.json
+++ b/bucket/intellij-jbr25-sdk-jcef.json
@@ -1,18 +1,18 @@
 {
-    "version": "25-b176.4",
+    "version": "25.0.1-b266.34",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
     "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25-windows-x64-b176.4.tar.gz",
-            "hash": "sha512:0fe244c33050455ce03df1e83d848eb2c26223f0ef5e578afb219a7f9dc3bd7ff416fc259fdf9f330daeaece924c73151293c8eb9b89d20d4cbf5f4b89a05d30",
-            "extract_dir": "jbrsdk_jcef-25-windows-x64-b176.4"
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25.0.1-windows-x64-b266.34.tar.gz",
+            "hash": "sha512:0f7ce9c070bd369217de9ab6a9dbaf3e1a3fd63f8c9df29f8f4d38b4de132f5fb436ecfeec096dbbe6478162971ee3627dadf0f07c70d62d259f0311a8d1c0bf",
+            "extract_dir": "jbrsdk_jcef-25.0.1-windows-x64-b266.34"
         },
         "arm64": {
-            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25-windows-aarch64-b176.4.tar.gz",
-            "hash": "sha512:1a715ecb1a40cca17b7fd8db6c4050cd6f8e798ab22e8bb29c841ab4690ff7a06697ea9f2510e873e5a5c671d2397d5d7b9d2ba95e142b7f944f00fd38214aab",
-            "extract_dir": "jbrsdk_jcef-25-windows-aarch64-b176.4"
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25.0.1-windows-aarch64-b266.34.tar.gz",
+            "hash": "sha512:2b44f60bf26a31599a9286fd2491a06f87e8cc2e4262daed71092816b34c0de51d5d08424858f81f00a0d61394b7ab8a0377a6dbc626748bedd69d13ec9569c8",
+            "extract_dir": "jbrsdk_jcef-25.0.1-windows-aarch64-b266.34"
         }
     },
     "env_set": {
@@ -26,38 +26,41 @@
             "$tags = $releases | ForEach-Object { $_.tag_name }",
             "# `$Script:expected_ver` is current version for fallback",
             "$tags += 'jbr-release-' + ($Script:expected_ver -replace '-', '')",
-            "$pattern = 'jbr-release-25b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
+            "$pattern = 'jbr-release-25\\.(?<Version>[\\d.]+)b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
             "$matches = foreach ($t in $tags) { if ($t -match $pattern) {",
             "    [PSCustomObject]@{",
             "      Tag = $t",
+            "      VersionParts = ($Matches.Version -split '\\.') | ForEach-Object { [int]$_ }",
             "      BuildNum = [int]$Matches.BuildNum",
             "      Patch = [int]$Matches.Patch",
             "    }",
             "  } }",
-            "$latest = $matches | Sort-Object @{Expression={$_.BuildNum}},",
+            "$latest = $matches | Sort-Object @{Expression={$_.VersionParts[0]}},",
+            "                                 @{Expression={$_.VersionParts[1]}},",
+            "                                 @{Expression={$_.BuildNum}},",
             "                                 @{Expression={$_.Patch}} | Select-Object -Last 1",
             "Write-Output $latest.Tag"
         ],
-        "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
-        "replace": "25-${Build}.${Patch}"
+        "regex": "jbr-release-25\\.(?<Version>[\\d.]+)(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
+        "replace": "25.${Version}-${Build}.${Patch}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25-windows-x64-$matchBuild.$matchPatch.tar.gz",
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25.$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
                     "regex": "$sha512\\s"
                 },
-                "extract_dir": "jbrsdk_jcef-25-windows-x64-$matchBuild.$matchPatch"
+                "extract_dir": "jbrsdk_jcef-25.$matchVersion-windows-x64-$matchBuild.$matchPatch"
             },
             "arm64": {
-                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25.$matchVersion-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
                     "regex": "$sha512\\s"
                 },
-                "extract_dir": "jbrsdk_jcef-25-windows-aarch64-$matchBuild.$matchPatch"
+                "extract_dir": "jbrsdk_jcef-25.$matchVersion-windows-aarch64-$matchBuild.$matchPatch"
             }
         }
     }

--- a/bucket/intellij-jbr25-sdk-jcef.json
+++ b/bucket/intellij-jbr25-sdk-jcef.json
@@ -1,5 +1,5 @@
 {
-    "version": "25b176.4",
+    "version": "25-b176.4",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
     "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
@@ -39,7 +39,7 @@
             "Write-Output $latest.Tag"
         ],
         "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
-        "replace": "25${Build}.${Patch}"
+        "replace": "25-${Build}.${Patch}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/intellij-jbr25-sdk-jcef.json
+++ b/bucket/intellij-jbr25-sdk-jcef.json
@@ -1,0 +1,64 @@
+{
+    "version": "25b176.4",
+    "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
+    "description": "A fork of OpenJDK that includes a number enhancements in font rendering, HiDPI support, ligatures, performance improvements, and bugfixes. These are mainly for running IntelliJ Platform-based products",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25-windows-x64-b176.4.tar.gz",
+            "hash": "sha512:0fe244c33050455ce03df1e83d848eb2c26223f0ef5e578afb219a7f9dc3bd7ff416fc259fdf9f330daeaece924c73151293c8eb9b89d20d4cbf5f4b89a05d30",
+            "extract_dir": "jbrsdk_jcef-25-windows-x64-b176.4"
+        },
+        "arm64": {
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25-windows-aarch64-b176.4.tar.gz",
+            "hash": "sha512:1a715ecb1a40cca17b7fd8db6c4050cd6f8e798ab22e8bb29c841ab4690ff7a06697ea9f2510e873e5a5c671d2397d5d7b9d2ba95e142b7f944f00fd38214aab",
+            "extract_dir": "jbrsdk_jcef-25-windows-aarch64-b176.4"
+        }
+    },
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "env_add_path": "bin",
+    "checkver": {
+        "script": [
+            "$url = 'https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases'",
+            "$releases = Invoke-RestMethod $url",
+            "$tags = $releases | ForEach-Object { $_.tag_name }",
+            "# `$Script:expected_ver` is current version for fallback",
+            "$tags += 'jbr-release-' + ($Script:expected_ver -replace '-', '')",
+            "$pattern = 'jbr-release-25b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
+            "$matches = foreach ($t in $tags) { if ($t -match $pattern) {",
+            "    [PSCustomObject]@{",
+            "      Tag = $t",
+            "      BuildNum = [int]$Matches.BuildNum",
+            "      Patch = [int]$Matches.Patch",
+            "    }",
+            "  } }",
+            "$latest = $matches | Sort-Object @{Expression={$_.BuildNum}},",
+            "                                 @{Expression={$_.Patch}} | Select-Object -Last 1",
+            "Write-Output $latest.Tag"
+        ],
+        "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
+        "replace": "25${Build}.${Patch}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25-windows-x64-$matchBuild.$matchPatch.tar.gz",
+                "hash": {
+                    "url": "$url.checksum",
+                    "regex": "$sha512\\s"
+                },
+                "extract_dir": "jbrsdk_jcef-25-windows-x64-$matchBuild.$matchPatch"
+            },
+            "arm64": {
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-25-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
+                "hash": {
+                    "url": "$url.checksum",
+                    "regex": "$sha512\\s"
+                },
+                "extract_dir": "jbrsdk_jcef-25-windows-aarch64-$matchBuild.$matchPatch"
+            }
+        }
+    }
+}

--- a/bucket/intellij-jbr25-sdk-jcef.json
+++ b/bucket/intellij-jbr25-sdk-jcef.json
@@ -1,7 +1,7 @@
 {
     "version": "25b176.4",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
-    "description": "A fork of OpenJDK that includes a number enhancements in font rendering, HiDPI support, ligatures, performance improvements, and bugfixes. These are mainly for running IntelliJ Platform-based products",
+    "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {

--- a/bucket/intellij-jbr25-sdk.json
+++ b/bucket/intellij-jbr25-sdk.json
@@ -1,18 +1,18 @@
 {
-    "version": "25-b176.4",
+    "version": "25.0.1-b266.34",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
     "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-x64-b176.4.tar.gz",
-            "hash": "sha512:408ec774e0911b5a59096755709effa67e6438c0e2048bf3a63fa03fbd104e9331899211f55f2679c82abf836e5e380c256714769666ac8c9e4470fd3f1f54a1",
-            "extract_dir": "jbrsdk-25-windows-x64-b176.4"
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25.0.1-windows-x64-b266.34.tar.gz",
+            "hash": "sha512:9cd81048244e3e696c6be131cc37868bcbb51db161fd327b26b79fddc280075d96f18487e2ad5f4b3164dabfaff3845c841a45f667584f0a87ccb9105317773b",
+            "extract_dir": "jbrsdk-25.0.1-windows-x64-b266.34"
         },
         "arm64": {
-            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-aarch64-b176.4.tar.gz",
-            "hash": "sha512:e9d535c97d12d951078f3508e5fd0d700cc081cf6823cef03e61a5c7fc5a49e8a4c6900a36ba0eb378a84c6ca5d1af53991fb0fe35f3e375bf034f1e53a4222e",
-            "extract_dir": "jbrsdk-25-windows-aarch64-b176.4"
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25.0.1-windows-aarch64-b266.34.tar.gz",
+            "hash": "sha512:d3b9bd219ff25c874ceb9a10f286e9ee1ceb091442b2357f22bdc7479ac442e7df86b419e918936fb9aa446ede9d710c446baca634bd21a81abb968af903eb53",
+            "extract_dir": "jbrsdk-25.0.1-windows-aarch64-b266.34"
         }
     },
     "env_set": {
@@ -26,38 +26,41 @@
             "$tags = $releases | ForEach-Object { $_.tag_name }",
             "# `$Script:expected_ver` is current version for fallback",
             "$tags += 'jbr-release-' + ($Script:expected_ver -replace '-', '')",
-            "$pattern = 'jbr-release-25b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
+            "$pattern = 'jbr-release-25\\.(?<Version>[\\d.]+)b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
             "$matches = foreach ($t in $tags) { if ($t -match $pattern) {",
             "    [PSCustomObject]@{",
             "      Tag = $t",
+            "      VersionParts = ($Matches.Version -split '\\.') | ForEach-Object { [int]$_ }",
             "      BuildNum = [int]$Matches.BuildNum",
             "      Patch = [int]$Matches.Patch",
             "    }",
             "  } }",
-            "$latest = $matches | Sort-Object @{Expression={$_.BuildNum}},",
+            "$latest = $matches | Sort-Object @{Expression={$_.VersionParts[0]}},",
+            "                                 @{Expression={$_.VersionParts[1]}},",
+            "                                 @{Expression={$_.BuildNum}},",
             "                                 @{Expression={$_.Patch}} | Select-Object -Last 1",
             "Write-Output $latest.Tag"
         ],
-        "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
-        "replace": "25-${Build}.${Patch}"
+        "regex": "jbr-release-25\\.(?<Version>[\\d.]+)(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
+        "replace": "25.${Version}-${Build}.${Patch}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-x64-$matchBuild.$matchPatch.tar.gz",
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25.$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
                     "regex": "$sha512\\s"
                 },
-                "extract_dir": "jbrsdk-25-windows-x64-$matchBuild.$matchPatch"
+                "extract_dir": "jbrsdk-25.$matchVersion-windows-x64-$matchBuild.$matchPatch"
             },
             "arm64": {
-                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25.$matchVersion-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
                     "regex": "$sha512\\s"
                 },
-                "extract_dir": "jbrsdk-25-windows-aarch64-$matchBuild.$matchPatch"
+                "extract_dir": "jbrsdk-25.$matchVersion-windows-aarch64-$matchBuild.$matchPatch"
             }
         }
     }

--- a/bucket/intellij-jbr25-sdk.json
+++ b/bucket/intellij-jbr25-sdk.json
@@ -1,0 +1,64 @@
+{
+    "version": "25b176.4",
+    "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
+    "description": "A fork of OpenJDK that includes a number enhancements in font rendering, HiDPI support, ligatures, performance improvements, and bugfixes. These are mainly for running IntelliJ Platform-based products",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-x64-b176.4.tar.gz",
+            "hash": "sha512:408ec774e0911b5a59096755709effa67e6438c0e2048bf3a63fa03fbd104e9331899211f55f2679c82abf836e5e380c256714769666ac8c9e4470fd3f1f54a1",
+            "extract_dir": "jbrsdk-25-windows-x64-b176.4"
+        },
+        "arm64": {
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-aarch64-b176.4.tar.gz",
+            "hash": "sha512:e9d535c97d12d951078f3508e5fd0d700cc081cf6823cef03e61a5c7fc5a49e8a4c6900a36ba0eb378a84c6ca5d1af53991fb0fe35f3e375bf034f1e53a4222e",
+            "extract_dir": "jbrsdk-25-windows-aarch64-b176.4"
+        }
+    },
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "env_add_path": "bin",
+    "checkver": {
+        "script": [
+            "$url = 'https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases'",
+            "$releases = Invoke-RestMethod $url",
+            "$tags = $releases | ForEach-Object { $_.tag_name }",
+            "# `$Script:expected_ver` is current version for fallback",
+            "$tags += 'jbr-release-' + ($Script:expected_ver -replace '-', '')",
+            "$pattern = 'jbr-release-25b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
+            "$matches = foreach ($t in $tags) { if ($t -match $pattern) {",
+            "    [PSCustomObject]@{",
+            "      Tag = $t",
+            "      BuildNum = [int]$Matches.BuildNum",
+            "      Patch = [int]$Matches.Patch",
+            "    }",
+            "  } }",
+            "$latest = $matches | Sort-Object @{Expression={$_.BuildNum}},",
+            "                                 @{Expression={$_.Patch}} | Select-Object -Last 1",
+            "Write-Output $latest.Tag"
+        ],
+        "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
+        "replace": "25${Build}.${Patch}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-x64-$matchBuild.$matchPatch.tar.gz",
+                "hash": {
+                    "url": "$url.checksum",
+                    "regex": "$sha512\\s"
+                },
+                "extract_dir": "jbrsdk-25-windows-x64-$matchBuild.$matchPatch"
+            },
+            "arm64": {
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
+                "hash": {
+                    "url": "$url.checksum",
+                    "regex": "$sha512\\s"
+                },
+                "extract_dir": "jbrsdk-25-windows-aarch64-$matchBuild.$matchPatch"
+            }
+        }
+    }
+}

--- a/bucket/intellij-jbr25-sdk.json
+++ b/bucket/intellij-jbr25-sdk.json
@@ -1,5 +1,5 @@
 {
-    "version": "25b176.4",
+    "version": "25-b176.4",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
     "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
@@ -39,7 +39,7 @@
             "Write-Output $latest.Tag"
         ],
         "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
-        "replace": "25${Build}.${Patch}"
+        "replace": "25-${Build}.${Patch}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/intellij-jbr25-sdk.json
+++ b/bucket/intellij-jbr25-sdk.json
@@ -1,7 +1,7 @@
 {
     "version": "25b176.4",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
-    "description": "A fork of OpenJDK that includes a number enhancements in font rendering, HiDPI support, ligatures, performance improvements, and bugfixes. These are mainly for running IntelliJ Platform-based products",
+    "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {

--- a/bucket/intellij-jbr25.json
+++ b/bucket/intellij-jbr25.json
@@ -1,18 +1,18 @@
 {
-    "version": "25-b176.4",
+    "version": "25.0.1-b266.34",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
     "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25-windows-x64-b176.4.tar.gz",
-            "hash": "sha512:5a3b6840e75f27ac663ea335d41f56f87f2f15f275db7f2ca92e05726c3452620016e3f227657625bafa22c954966a2a0c060a5eb22ecedef1c5301f18a425c2",
-            "extract_dir": "jbr-25-windows-x64-b176.4"
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25.0.1-windows-x64-b266.34.tar.gz",
+            "hash": "sha512:e510033b056d7b396ee4d02f01ad3f70cd1ac2eb3ffac5d340bb8874a91fe9540f5cdb3bf84d22ac447af3f998c4e426d25aa924e39391b2d5067502b29bcaea",
+            "extract_dir": "jbr-25.0.1-windows-x64-b266.34"
         },
         "arm64": {
-            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25-windows-aarch64-b176.4.tar.gz",
-            "hash": "sha512:ee281a15f2c161696620fb6f32825c4461423911507ab41fed142fb8039a795234e355e8084fd84014bebc6b119486e49c3fc1950389b413d6dcd3af64ad20c7",
-            "extract_dir": "jbr-25-windows-aarch64-b176.4"
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25.0.1-windows-aarch64-b266.34.tar.gz",
+            "hash": "sha512:cb7d4e32207d24c95efb27dcc8d769fac80975c3646f5841ebc2396ed7f5c964043ae7c58b0e2d20019f5e10590347cbda8226509e3c8577e58571445ebc7c62",
+            "extract_dir": "jbr-25.0.1-windows-aarch64-b266.34"
         }
     },
     "env_set": {
@@ -26,38 +26,41 @@
             "$tags = $releases | ForEach-Object { $_.tag_name }",
             "# `$Script:expected_ver` is current version for fallback",
             "$tags += 'jbr-release-' + ($Script:expected_ver -replace '-', '')",
-            "$pattern = 'jbr-release-25b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
+            "$pattern = 'jbr-release-25\\.(?<Version>[\\d.]+)b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
             "$matches = foreach ($t in $tags) { if ($t -match $pattern) {",
             "    [PSCustomObject]@{",
             "      Tag = $t",
+            "      VersionParts = ($Matches.Version -split '\\.') | ForEach-Object { [int]$_ }",
             "      BuildNum = [int]$Matches.BuildNum",
             "      Patch = [int]$Matches.Patch",
             "    }",
             "  } }",
-            "$latest = $matches | Sort-Object @{Expression={$_.BuildNum}},",
+            "$latest = $matches | Sort-Object @{Expression={$_.VersionParts[0]}},",
+            "                                 @{Expression={$_.VersionParts[1]}},",
+            "                                 @{Expression={$_.BuildNum}},",
             "                                 @{Expression={$_.Patch}} | Select-Object -Last 1",
             "Write-Output $latest.Tag"
         ],
-        "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
-        "replace": "25-${Build}.${Patch}"
+        "regex": "jbr-release-25\\.(?<Version>[\\d.]+)(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
+        "replace": "25.${Version}-${Build}.${Patch}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25-windows-x64-$matchBuild.$matchPatch.tar.gz",
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25.$matchVersion-windows-x64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
                     "regex": "$sha512\\s"
                 },
-                "extract_dir": "jbr-25-windows-x64-$matchBuild.$matchPatch"
+                "extract_dir": "jbr-25.$matchVersion-windows-x64-$matchBuild.$matchPatch"
             },
             "arm64": {
-                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25.$matchVersion-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
                 "hash": {
                     "url": "$url.checksum",
                     "regex": "$sha512\\s"
                 },
-                "extract_dir": "jbr-25-windows-aarch64-$matchBuild.$matchPatch"
+                "extract_dir": "jbr-25.$matchVersion-windows-aarch64-$matchBuild.$matchPatch"
             }
         }
     }

--- a/bucket/intellij-jbr25.json
+++ b/bucket/intellij-jbr25.json
@@ -1,5 +1,5 @@
 {
-    "version": "25b176.4",
+    "version": "25-b176.4",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
     "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
@@ -39,7 +39,7 @@
             "Write-Output $latest.Tag"
         ],
         "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
-        "replace": "25${Build}.${Patch}"
+        "replace": "25-${Build}.${Patch}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/intellij-jbr25.json
+++ b/bucket/intellij-jbr25.json
@@ -1,0 +1,64 @@
+{
+    "version": "25b176.4",
+    "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
+    "description": "A fork of OpenJDK that includes a number enhancements in font rendering, HiDPI support, ligatures, performance improvements, and bugfixes. These are mainly for running IntelliJ Platform-based products",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25-windows-x64-b176.4.tar.gz",
+            "hash": "sha512:5a3b6840e75f27ac663ea335d41f56f87f2f15f275db7f2ca92e05726c3452620016e3f227657625bafa22c954966a2a0c060a5eb22ecedef1c5301f18a425c2",
+            "extract_dir": "jbr-25-windows-x64-b176.4"
+        },
+        "arm64": {
+            "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25-windows-aarch64-b176.4.tar.gz",
+            "hash": "sha512:ee281a15f2c161696620fb6f32825c4461423911507ab41fed142fb8039a795234e355e8084fd84014bebc6b119486e49c3fc1950389b413d6dcd3af64ad20c7",
+            "extract_dir": "jbr-25-windows-aarch64-b176.4"
+        }
+    },
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "env_add_path": "bin",
+    "checkver": {
+        "script": [
+            "$url = 'https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases'",
+            "$releases = Invoke-RestMethod $url",
+            "$tags = $releases | ForEach-Object { $_.tag_name }",
+            "# `$Script:expected_ver` is current version for fallback",
+            "$tags += 'jbr-release-' + ($Script:expected_ver -replace '-', '')",
+            "$pattern = 'jbr-release-25b(?<BuildNum>[\\d]+)\\.(?<Patch>\\d+)'",
+            "$matches = foreach ($t in $tags) { if ($t -match $pattern) {",
+            "    [PSCustomObject]@{",
+            "      Tag = $t",
+            "      BuildNum = [int]$Matches.BuildNum",
+            "      Patch = [int]$Matches.Patch",
+            "    }",
+            "  } }",
+            "$latest = $matches | Sort-Object @{Expression={$_.BuildNum}},",
+            "                                 @{Expression={$_.Patch}} | Select-Object -Last 1",
+            "Write-Output $latest.Tag"
+        ],
+        "regex": "jbr-release-25(?<Build>[\\w]+)\\.(?<Patch>[\\d]+)",
+        "replace": "25${Build}.${Patch}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25-windows-x64-$matchBuild.$matchPatch.tar.gz",
+                "hash": {
+                    "url": "$url.checksum",
+                    "regex": "$sha512\\s"
+                },
+                "extract_dir": "jbr-25-windows-x64-$matchBuild.$matchPatch"
+            },
+            "arm64": {
+                "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25-windows-aarch64-$matchBuild.$matchPatch.tar.gz",
+                "hash": {
+                    "url": "$url.checksum",
+                    "regex": "$sha512\\s"
+                },
+                "extract_dir": "jbr-25-windows-aarch64-$matchBuild.$matchPatch"
+            }
+        }
+    }
+}

--- a/bucket/intellij-jbr25.json
+++ b/bucket/intellij-jbr25.json
@@ -1,7 +1,7 @@
 {
     "version": "25b176.4",
     "homepage": "https://github.com/JetBrains/JetBrainsRuntime",
-    "description": "A fork of OpenJDK that includes a number enhancements in font rendering, HiDPI support, ligatures, performance improvements, and bugfixes. These are mainly for running IntelliJ Platform-based products",
+    "description": "A fork of OpenJDK that supports enhanced class redefinition (DCEVM), features optional JCEF, a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #576
<!-- or -->
<!-- Relates to #XXXX -->


intellij-jbr25*: JetBrains Runtime is a fork of [OpenJDK](https://github.com/openjdk/jdk) available for Windows, Mac OS X, and Linux. It supports enhanced class redefinition ([DCEVM](https://ssw.jku.at/dcevm/)), features optional [JCEF](https://github.com/JetBrains/jcef), a framework for embedding Chromium-based browsers, includes a number of improvements in font rendering, keyboards support, windowing/focus subsystems, HiDPI, accessibility, and performance, provides better desktop integration and bugfixes not yet present in OpenJDK.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JetBrains Runtime 25 in four variants: runtime, SDK, runtime+JCEF, and SDK+JCEF.
  * Windows x64 and ARM64 packages with per-architecture downloads and extraction.
  * Built-in automatic version detection and autoupdate from upstream releases.
  * Environment setup: sets JAVA_HOME and adds runtime bin to PATH for immediate use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->