### PR TITLE
Fix corretto25-jdk install issues

### DIFF
--- a/bucket/corretto25-jdk.json
+++ b/bucket/corretto25-jdk.json
@@ -9,7 +9,7 @@
             "hash": "ee94067183891ae5ae1f4771ea715f1114333ebf64f61e3ad1b34a38eed65dfc"
         }
     },
-    "extract_dir": "jdk25.0.2_$matchBuild",
+    "extract_dir": "jdk25.0.2_10",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -29,6 +29,6 @@
                 }
             }
         },
-        "extract_dir": "jdk$matchHead_$matchBuild"
+        "extract_dir": "jdk$matchHead_$buildVersion"
     }
 }


### PR DESCRIPTION
Fixed the install issues with corretto25-jdk. Updated the script to use the extraction_dir format used by previous working versions of the script. 

Fixing Issue #575 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JDK Corretto 25 build configuration and versioning parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->