### PR TITLE
openjdk: fix checkver for superseded release pages

### DIFF
--- a/bucket/openjdk.json
+++ b/bucket/openjdk.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/25",
-        "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
+        "url": "https://jdk.java.net/archive/",
+        "re": "https://download\\.java\\.net/java/(?<type>GA)/(?<path>jdk(?<major>[\\d.]+)/[^/]+/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin\\.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },
     "autoupdate": {

--- a/bucket/openjdk17.json
+++ b/bucket/openjdk17.json
@@ -15,7 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
+        "url": "https://jdk.java.net/archive/",
+        "re": "https://download\\.java\\.net/java/(?<type>GA)/(?<path>jdk(?<major>17(?:\\.[\\d]+)*)/[^/]+/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>17(?:\\.[\\d]+)*)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin\\.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },
     "autoupdate": {

--- a/bucket/openjdk20.json
+++ b/bucket/openjdk20.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/20",
-        "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
+        "url": "https://jdk.java.net/archive/",
+        "re": "https://download\\.java\\.net/java/(?<type>GA)/(?<path>jdk(?<major>20(?:\\.[\\d]+)*)/[^/]+/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>20(?:\\.[\\d]+)*)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin\\.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },
     "autoupdate": {

--- a/bucket/openjdk21.json
+++ b/bucket/openjdk21.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/21",
-        "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
+        "url": "https://jdk.java.net/archive/",
+        "re": "https://download\\.java\\.net/java/(?<type>GA)/(?<path>jdk(?<major>21(?:\\.[\\d]+)*)/[^/]+/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>21(?:\\.[\\d]+)*)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin\\.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },
     "autoupdate": {

--- a/bucket/openjdk22.json
+++ b/bucket/openjdk22.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/22",
-        "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
+        "url": "https://jdk.java.net/archive/",
+        "re": "https://download\\.java\\.net/java/(?<type>GA)/(?<path>jdk(?<major>22(?:\\.[\\d]+)*)/[^/]+/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>22(?:\\.[\\d]+)*)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin\\.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },
     "autoupdate": {

--- a/bucket/openjdk23.json
+++ b/bucket/openjdk23.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/23",
-        "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
+        "url": "https://jdk.java.net/archive/",
+        "re": "https://download\\.java\\.net/java/(?<type>GA)/(?<path>jdk(?<major>23(?:\\.[\\d]+)*)/[^/]+/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>23(?:\\.[\\d]+)*)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin\\.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },
     "autoupdate": {

--- a/bucket/openjdk24.json
+++ b/bucket/openjdk24.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/24",
-        "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
+        "url": "https://jdk.java.net/archive/",
+        "re": "https://download\\.java\\.net/java/(?<type>GA)/(?<path>jdk(?<major>24(?:\\.[\\d]+)*)/[^/]+/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>24(?:\\.[\\d]+)*)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin\\.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },
     "autoupdate": {

--- a/bucket/openjdk25.json
+++ b/bucket/openjdk25.json
@@ -15,8 +15,8 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://jdk.java.net/25",
-        "re": "/(?<type>early_access|GA)/(?<path>jdk(?<major>[\\d.]+)(?:.*)?/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>[\\d.]+)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin.(zip|tar.gz))",
+        "url": "https://jdk.java.net/archive/",
+        "re": "https://download\\.java\\.net/java/(?<type>GA)/(?<path>jdk(?<major>25(?:\\.[\\d]+)*)/[^/]+/(?<build>[\\d]+)(?:/GPL|/binaries)?)/(?<file>openjdk-(?<version>25(?:\\.[\\d]+)*)(?<ea>-ea)?(?:\\+[\\d]+)?_windows-x64_bin\\.(zip|tar.gz))",
         "replace": "${version}-${build}${ea}"
     },
     "autoupdate": {


### PR DESCRIPTION
Relates to #585

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

## Summary

- fix `checkver` for `openjdk`, `openjdk17`, and `openjdk20` through `openjdk25`
- switch those manifests from superseded `jdk.java.net/<major>` pages to `https://jdk.java.net/archive/`
- keep the change scoped to manifests whose current pinned versions are still directly discoverable in the archive

## Out of scope

- `openjdk18` and `openjdk19` are still affected, but I left them out of this PR because the archive no longer exposes the exact versions those manifests currently point to (`18.0.2.1-1` and `19.0.2-7`)
- those two look like separate follow-up work rather than a safe drop-in archive switch

## Verification

- `checkver.ps1 bucket/openjdk.json` -> `25.0.2-10`
- `checkver.ps1 bucket/openjdk17.json` -> `17.0.2-8`
- `checkver.ps1 bucket/openjdk20.json` -> `20.0.2-9`
- `checkver.ps1 bucket/openjdk21.json` -> `21.0.2-13`
- `checkver.ps1 bucket/openjdk22.json` -> `22.0.2-9`
- `checkver.ps1 bucket/openjdk23.json` -> `23.0.2-7`
- `checkver.ps1 bucket/openjdk24.json` -> `24.0.2-12`
- `checkver.ps1 bucket/openjdk25.json` -> `25.0.2-10`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenJDK version detection and verification configuration for all supported releases (versions 17-25). Modified how version information is retrieved by consolidating sources to use a centralized archive endpoint instead of individual release landing pages, enhancing consistency and reliability in automated version discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->