### PR TITLE
temurin11*: update to 11.0.30-7 and remove 32-bit

### DIFF
--- a/bucket/temurin11-jdk.json
+++ b/bucket/temurin11-jdk.json
@@ -1,19 +1,15 @@
 {
     "description": "Eclipse Temurin is a runtime provided by Eclipse Adoptium for general use across the Java ecosystem",
     "homepage": "https://adoptium.net",
-    "version": "11.0.29-7",
+    "version": "11.0.30-7",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29+7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.29_7.zip",
-            "hash": "c21b63f6391b9d8f8aa969fb99250de797539cfb54232f5d4d371993f0c235b5"
-        },
-        "32bit": {
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29+7/OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.29_7.zip",
-            "hash": "0b5bb836546f86aab9ffe53a14ae51f4801c5a020383d7ea88a054091676698c"
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.30+7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.30_7.zip",
+            "hash": "925a63cb019fd605579e639980e99abefb3186e79f36979183dc45b294d6bf0f"
         }
     },
-    "extract_dir": "jdk-11.0.29+7",
+    "extract_dir": "jdk-11.0.30+7",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -33,9 +29,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/$matchLink/download/$matchTag/$matchName"
-            },
-            "32bit": {
-                "url": "https://github.com/$matchLink/download/$matchTag/$matchPrefix_x86-32_$matchSuffix"
             }
         },
         "hash": {

--- a/bucket/temurin11-jre.json
+++ b/bucket/temurin11-jre.json
@@ -1,19 +1,15 @@
 {
     "description": "Eclipse Temurin is a runtime provided by Eclipse Adoptium for general use across the Java ecosystem",
     "homepage": "https://adoptium.net",
-    "version": "11.0.29-7",
+    "version": "11.0.30-7",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29+7/OpenJDK11U-jre_x64_windows_hotspot_11.0.29_7.zip",
-            "hash": "b619e5e2434ac1a6cf7a33d6e93827d832a16484e4d0beb9fff60760472ae76a"
-        },
-        "32bit": {
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.29+7/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.29_7.zip",
-            "hash": "b747698a05a39391a58b9caac30310275e4e6bd9fef92d6c149cba310d91d2be"
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.30+7/OpenJDK11U-jre_x64_windows_hotspot_11.0.30_7.zip",
+            "hash": "db7fe2f05857074e73ef2bb10bfb95556ad110cf1ba0c82d101f93b3a93862ff"
         }
     },
-    "extract_dir": "jdk-11.0.29+7-jre",
+    "extract_dir": "jdk-11.0.30+7-jre",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
@@ -33,9 +29,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/$matchLink/download/$matchTag/$matchName"
-            },
-            "32bit": {
-                "url": "https://github.com/$matchLink/download/$matchTag/$matchPrefix_x86-32_$matchSuffix"
             }
         },
         "hash": {


### PR DESCRIPTION
Closes #588

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

## Summary

- update `temurin11-jdk` and `temurin11-jre` to `11.0.30-7`
- remove the `32bit` architecture entries from both manifests
- keep the change scoped to Temurin 11 only

## Why this changed

Adoptium no longer ships Windows `x86-32` ZIP assets for Temurin 11 in `11.0.30+7`.

`11.0.29+7` still shipped those Win32 assets, but `11.0.30+7` does not, so this is no longer a plain stale-only refresh. This PR aligns the manifests with the currently published upstream support.

## Verification

- confirmed `jdk-11.0.30+7` still ships:
  - `OpenJDK11U-jdk_x64_windows_hotspot_11.0.30_7.zip`
  - `OpenJDK11U-jre_x64_windows_hotspot_11.0.30_7.zip`
- confirmed `jdk-11.0.30+7` no longer ships:
  - `OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.30_7.zip`
  - `OpenJDK11U-jre_x86-32_windows_hotspot_11.0.30_7.zip`
- refreshed x64 hashes from the current release assets
- JSON remains valid for both manifests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java Temurin 11 (JDK/JRE) to version 11.0.30-7, including refreshed Windows x64 download artifacts and updated checksums for verification
  * Removed 32-bit Windows architecture support; only 64-bit is now supported for Java Temurin 11 deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->