### PR TITLE
liberica*: Fix checkver JSONPath

### DIFF
--- a/bucket/liberica-full-jdk.json
+++ b/bucket/liberica-full-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica-full-jre.json
+++ b/bucket/liberica-full-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica-full-lts-jdk.json
+++ b/bucket/liberica-full-lts-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica-full-lts-jre.json
+++ b/bucket/liberica-full-lts-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica-jdk.json
+++ b/bucket/liberica-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica-jre.json
+++ b/bucket/liberica-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica-lite-jdk.json
+++ b/bucket/liberica-lite-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica-lite-lts-jdk.json
+++ b/bucket/liberica-lite-lts-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk-lite&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica-lts-jdk.json
+++ b/bucket/liberica-lts-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jdk&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica-lts-jre.json
+++ b/bucket/liberica-lts-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?bundle-type=jre&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}",
         "reverse": true

--- a/bucket/liberica11-full-jdk.json
+++ b/bucket/liberica11-full-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica11-full-jre.json
+++ b/bucket/liberica11-full-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica11-jdk.json
+++ b/bucket/liberica11-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica11-jre.json
+++ b/bucket/liberica11-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica11-lite-jdk.json
+++ b/bucket/liberica11-lite-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=11&bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica16-full-jdk.json
+++ b/bucket/liberica16-full-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=16&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica16-full-jre.json
+++ b/bucket/liberica16-full-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=16&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica16-jdk.json
+++ b/bucket/liberica16-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=16&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica16-jre.json
+++ b/bucket/liberica16-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=16&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica16-lite-jdk.json
+++ b/bucket/liberica16-lite-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=16&bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica17-full-jdk.json
+++ b/bucket/liberica17-full-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=17&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica17-full-jre.json
+++ b/bucket/liberica17-full-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=17&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica17-jdk.json
+++ b/bucket/liberica17-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=17&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica17-jre.json
+++ b/bucket/liberica17-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=17&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica17-lite-jdk.json
+++ b/bucket/liberica17-lite-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=17&bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-full-jdk.json
+++ b/bucket/liberica21-full-jdk.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-full-jre.json
+++ b/bucket/liberica21-full-jre.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-full-lts-jdk.json
+++ b/bucket/liberica21-full-lts-jdk.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-full-lts-jre.json
+++ b/bucket/liberica21-full-lts-jre.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-jdk.json
+++ b/bucket/liberica21-jdk.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-jre.json
+++ b/bucket/liberica21-jre.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-lite-jdk.json
+++ b/bucket/liberica21-lite-jdk.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-lite-lts-jdk.json
+++ b/bucket/liberica21-lite-lts-jdk.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk-lite&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-lts-jdk.json
+++ b/bucket/liberica21-lts-jdk.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jdk&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica21-lts-jre.json
+++ b/bucket/liberica21-lts-jre.json
@@ -24,7 +24,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=21&bundle-type=jre&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-full-jdk.json
+++ b/bucket/liberica25-full-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-full-jre.json
+++ b/bucket/liberica25-full-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-full-lts-jdk.json
+++ b/bucket/liberica25-full-lts-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jdk-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-full-lts-jre.json
+++ b/bucket/liberica25-full-lts-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jre-full&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-jdk.json
+++ b/bucket/liberica25-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-jre.json
+++ b/bucket/liberica25-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-lite-jdk.json
+++ b/bucket/liberica25-lite-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jdk-lite&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-lite-lts-jdk.json
+++ b/bucket/liberica25-lite-lts-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jdk-lite&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-lts-jdk.json
+++ b/bucket/liberica25-lts-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jdk&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica25-lts-jre.json
+++ b/bucket/liberica25-lts-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=25&bundle-type=jre&version-modifier=latest&release-type=lts&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\d.]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica8-full-jdk.json
+++ b/bucket/liberica8-full-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=8&bundle-type=jdk-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\du]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica8-full-jre.json
+++ b/bucket/liberica8-full-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=8&bundle-type=jre-full&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\du]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica8-jdk.json
+++ b/bucket/liberica8-jdk.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=8&bundle-type=jdk&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\du]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },

--- a/bucket/liberica8-jre.json
+++ b/bucket/liberica8-jre.json
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://api.bell-sw.com/v1/liberica/releases?version-feature=8&bundle-type=jre&version-modifier=latest&release-type=all&os=windows&arch=x86&installation-type=archive&package-type=zip&output=json&fields=version",
-        "jsonpath": "$.version",
+        "jsonpath": "$[*].version",
         "regex": "(?<major>[\\du]+)(?:\\+)(?<build>[\\d]+)",
         "replace": "${major}-${build}"
     },


### PR DESCRIPTION
Closes #547

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

## Summary

BellSoft's Liberica API returns an array of release objects for these `checkver` endpoints, but the manifests currently use `$.version`.

That still lets `checkver` find a version, but it also emits:

```text
Property 'version' not valid on JArray.
```

This updates the affected Liberica manifests to read versions from the array with `$[*].version`.

No package URLs, hashes, versions, architecture entries, or install logic are changed.

## Verification

Ran `checkver` against all changed Liberica manifests. The manifests resolve to their current versions without the `JArray` warning.

Also spot-checked URLs for representative variants:

```powershell
.\bin\checkurls.ps1 -App liberica-jdk -Dir .\bucket
.\bin\checkurls.ps1 -App liberica-lts-jdk -Dir .\bucket
.\bin\checkurls.ps1 -App liberica8-jre -Dir .\bucket
```

Results:

```text
[2][2][0] liberica-jdk
[2][2][0] liberica-lts-jdk
[2][2][0] liberica8-jre
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated version detection configuration across 48 Liberica JDK and JRE package manifests to improve how available versions are discovered from the release API, enabling proper parsing of array-based API responses for autoupdate functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->