### PR TITLE
graalvm-oracle*: update releases and fix checkver

### DIFF
--- a/bucket/graalvm-oracle-17jdk.json
+++ b/bucket/graalvm-oracle-17jdk.json
@@ -21,9 +21,9 @@
         "GRAALVM_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://www.oracle.com/java/technologies/downloads/",
+        "url": "https://www.oracle.com/java/technologies/javase/graalvm-jdk17-archive-downloads.html",
         "useragent": "Mozilla/5.0",
-        "regex": "GraalVM for JDK ((?<ver>17)\\.[\\d.]+) downloads"
+        "regex": "graalvm-jdk-((?<ver>17)\\.(?<build>[\\d.]+))_windows-x64_bin\\.zip"
     },
     "autoupdate": {
         "url": "https://download.oracle.com/graalvm/$matchVer/archive/graalvm-jdk-$version_windows-x64_bin.zip",

--- a/bucket/graalvm-oracle-21jdk.json
+++ b/bucket/graalvm-oracle-21jdk.json
@@ -1,13 +1,13 @@
 {
     "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
-    "version": "21.0.8",
+    "version": "21.0.11",
     "homepage": "https://www.graalvm.org/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.oracle.com/downloads/licenses/graal-free-license.html"
     },
-    "url": "https://download.oracle.com/graalvm/21/archive/graalvm-jdk-21.0.8_windows-x64_bin.zip",
-    "hash": "0401a5c9b4a5478640b0d5563a5e0f2c97513ab689c5ee647d41293b92eed0e4",
+    "url": "https://download.oracle.com/graalvm/21/archive/graalvm-jdk-21.0.11_windows-x64_bin.zip",
+    "hash": "fc487b76723a922eb65885e5fada8333bca64b752417a4cfa76ebec2a048666b",
     "extract_to": "tmp",
     "installer": {
         "script": [
@@ -21,9 +21,9 @@
         "GRAALVM_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://www.oracle.com/java/technologies/downloads/",
+        "url": "https://docs.oracle.com/en/graalvm/jdk/21/docs/release-notes/",
         "useragent": "Mozilla/5.0",
-        "regex": "GraalVM for JDK ((?<ver>21)\\.(?<build>[\\d.]+)) downloads"
+        "regex": "Oracle GraalVM for JDK ((?<ver>21)\\.(?<build>[\\d.]+))"
     },
     "autoupdate": {
         "url": "https://download.oracle.com/graalvm/$matchVer/archive/graalvm-jdk-$version_windows-x64_bin.zip",

--- a/bucket/graalvm-oracle-jdk.json
+++ b/bucket/graalvm-oracle-jdk.json
@@ -1,13 +1,13 @@
 {
     "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
-    "version": "24.0.2",
+    "version": "25.0.3",
     "homepage": "https://www.graalvm.org/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.oracle.com/downloads/licenses/graal-free-license.html"
     },
-    "url": "https://download.oracle.com/graalvm/24/archive/graalvm-jdk-24.0.2_windows-x64_bin.zip",
-    "hash": "a70785104855c181f2b56993d117e0e991eab6bd6dde99c32c2c5af857756653",
+    "url": "https://download.oracle.com/graalvm/25/archive/graalvm-jdk-25.0.3_windows-x64_bin.zip",
+    "hash": "8678e147a7e3c32eca47f1466d199b5c7346c9aad2ee55b51ebdf504d6ea7c72",
     "extract_to": "tmp",
     "installer": {
         "script": [
@@ -21,9 +21,9 @@
         "GRAALVM_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://www.oracle.com/java/technologies/downloads/",
+        "url": "https://docs.oracle.com/en/graalvm/jdk/25/docs/release-notes/",
         "useragent": "Mozilla/5.0",
-        "regex": "GraalVM for JDK ((?<ver>[\\d]*)\\.[\\d.]+) downloads"
+        "regex": "Oracle GraalVM ((?<ver>25)\\.(?<build>[\\d.]+))"
     },
     "autoupdate": {
         "url": "https://download.oracle.com/graalvm/$matchVer/archive/graalvm-jdk-$version_windows-x64_bin.zip",


### PR DESCRIPTION
Relates to #472

This updates the existing Oracle GraalVM manifests to use current Oracle-owned sources for version detection.

Changes:
- `graalvm-oracle-jdk` now tracks Oracle GraalVM 25.0.3 from the Oracle GraalVM 25 release notes.
- `graalvm-oracle-21jdk` now tracks Oracle GraalVM for JDK 21.0.11 from the Oracle GraalVM JDK 21 release notes.
- `graalvm-oracle-17jdk` remains at 17.0.12 and now checks the JDK 17 archive page for 17.0.12 and earlier.

Design decisions:
- The active 25 and 21 manifests keep version-specific archive URLs, with hashes from Oracle's matching `.sha256` files.
- JDK 17 is not bumped to 17.0.13 or newer here because Oracle moved those CPU releases to the GraalVM OTN license/download path. The public archive page used by the current manifest only covers 17.0.12 and earlier.
- No third-party version source is used.

Validation:
- `checkver.ps1 graalvm-oracle-jdk` -> `25.0.3`
- `checkver.ps1 graalvm-oracle-21jdk` -> `21.0.11`
- `checkver.ps1 graalvm-oracle-17jdk` -> `17.0.12`
- `checkurls.ps1` passes for all three manifests: `[1][1][0]`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * GraalVM Oracle JDK 21 updated to version 21.0.11, incorporating latest improvements and updates
  * GraalVM Oracle JDK 25 updated to version 25.0.3 with the latest enhancements
  * Enhanced version detection and release verification mechanisms across all supported JDK versions for better accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->