### PR TITLE
graalvm*: add CE JDK 17 and fix CE JDK 21 checkver

### DIFF
--- a/bucket/graalvm-ce-17jdk.json
+++ b/bucket/graalvm-ce-17jdk.json
@@ -1,10 +1,10 @@
 {
     "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
-    "version": "21.0.2",
+    "version": "17.0.9",
     "homepage": "https://www.graalvm.org/",
     "license": "GPL-2.0",
-    "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_windows-x64_bin.zip",
-    "hash": "e17b7bead097bf372a5c75df17815b0a2f30b777a019d25eff7706b21421f7fa",
+    "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-17.0.9/graalvm-community-jdk-17.0.9_windows-x64_bin.zip",
+    "hash": "285e045bfc0b87d2b61958fea97444c3c6c7e68fba3fdbbe146622328b52ec38",
     "extract_to": "tmp",
     "installer": {
         "script": [
@@ -20,7 +20,7 @@
     "checkver": {
         "url": "https://api.github.com/repos/graalvm/graalvm-ce-builds/releases?per_page=100",
         "jsonpath": "$[*].tag_name",
-        "regex": "jdk-(21[\\d.]+)"
+        "regex": "jdk-(17[\\d.]+)"
     },
     "autoupdate": {
         "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-$version/graalvm-community-jdk-$version_windows-x64_bin.zip",

--- a/bucket/graalvm-ce-17jdk.json
+++ b/bucket/graalvm-ce-17jdk.json
@@ -20,7 +20,7 @@
     "checkver": {
         "url": "https://api.github.com/repos/graalvm/graalvm-ce-builds/releases?per_page=100",
         "jsonpath": "$[*].tag_name",
-        "regex": "jdk-(17[\\d.]+)"
+        "regex": "jdk-(17\\.[\\d.]+)"
     },
     "autoupdate": {
         "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-$version/graalvm-community-jdk-$version_windows-x64_bin.zip",

--- a/bucket/graalvm21-jdk21.json
+++ b/bucket/graalvm21-jdk21.json
@@ -20,7 +20,7 @@
     "checkver": {
         "url": "https://api.github.com/repos/graalvm/graalvm-ce-builds/releases?per_page=100",
         "jsonpath": "$[*].tag_name",
-        "regex": "jdk-(21[\\d.]+)"
+        "regex": "jdk-(21\\.[\\d.]+)"
     },
     "autoupdate": {
         "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-$version/graalvm-community-jdk-$version_windows-x64_bin.zip",


### PR DESCRIPTION
- Closes #472
- Closes #508

This handles the still-useful Community Edition part of #508 without reusing its stale manifest shape directly.

Changes:
- Add `graalvm-ce-17jdk` for GraalVM Community JDK 17.0.9, using the naming discussed in #472.
- Keep the existing `graalvm21-jdk21` manifest for Community JDK 21, but change its `checkver` source away from `releases/latest` so it can still see the latest 21.x release instead of only the latest 25.x release.

Design decisions:
- `graalvm-ce-17jdk` uses the same `extract_to` plus installer move pattern as the existing newer GraalVM manifests, so it does not depend on the internal extracted directory name.
- `graalvm21-jdk21` already covers the Community JDK 21 package requested in #508, so this PR fixes its version detection rather than adding a duplicate manifest under another name.
- The version source is the official `graalvm/graalvm-ce-builds` GitHub releases API, not a third-party source.

Validation:
- `checkver.ps1 graalvm-ce-17jdk` -> `17.0.9`
- `checkver.ps1 graalvm21-jdk21` -> `21.0.2`
- `checkurls.ps1 graalvm-ce-17jdk` -> `[1][1][0]`
- `checkurls.ps1 graalvm21-jdk21` -> `[1][1][0]`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GraalVM Community Edition JDK 17 for Windows x64 with packaged installer and automatic environment setup (PATH, JAVA_HOME, GRAALVM_HOME).

* **Improvements**
  * Improved version checking for GraalVM JDK 21 to provide more reliable and timely update detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->