### PR TITLE
corretto11-jdk: fix 32-bit download URL

### DIFF
--- a/bucket/corretto11-jdk.json
+++ b/bucket/corretto11-jdk.json
@@ -9,7 +9,7 @@
             "hash": "462f2a455d8f8da1a3a839a0f3de10c7a5fe6f7d230cf995e144a769382f4afe"
         },
         "32bit": {
-            "url": "https://corretto.aws/downloads/resources/11.0.31.11.1/amazon-corretto-11.0.31.11.1-windows-x86-jre.zip",
+            "url": "https://corretto.aws/downloads/resources/11.0.31.11.1/amazon-corretto-11.0.31.11.1-windows-x86-jdk.zip",
             "hash": "8bf7d4329575956a5fbd6eb4afdea0121e50e62b2525d662d0a6fa9e73f7f579"
         }
     },
@@ -33,7 +33,7 @@
                 }
             },
             "32bit": {
-                "url": "https://corretto.aws/downloads/resources/$version/amazon-corretto-$version-windows-x86-jre.zip",
+                "url": "https://corretto.aws/downloads/resources/$version/amazon-corretto-$version-windows-x86-jdk.zip",
                 "hash": {
                     "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
                     "jsonpath": "$.windows.x86.jdk.11.zip.checksum_sha256"


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

## Summary

- fix the `32bit` URL in `corretto11-jdk`
- keep the current version and hashes unchanged
- keep the change scoped to the one broken manifest entry

## Why this changed

`corretto11-jdk` currently points its `32bit` asset to:

`amazon-corretto-11.0.31.11.1-windows-x86-jre.zip`

That URL now returns `403`, and it is also the wrong asset type for a JDK manifest.

Amazon's current Corretto metadata still publishes the Windows x86 JDK ZIP for 11 under:

`amazon-corretto-11.0.31.11.1-windows-x86-jdk.zip`

The manifest already uses the matching x86 JDK SHA-256 from the same metadata source, so this change just aligns the URL with the asset and checksum that are already intended.

## Verification

- `checkhashes.ps1 -Dir .\bucket corretto11-jdk` -> `corretto11-jdk: OK`
- `checkver.ps1 corretto11-jdk` -> `11.0.31.11.1`
- confirmed:
  - `windows-x86-jdk.zip` returns `200 OK`
  - `windows-x86-jre.zip` returns `403`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated 32-bit Windows artifact downloads to provide the JDK package instead of the JRE runtime, ensuring users receive the full development kit with necessary tools and libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->