### PR TITLE
corretto-lts-jdk: update from JDK 17 to JDK 21

### DIFF
--- a/bucket/corretto-lts-jdk.json
+++ b/bucket/corretto-lts-jdk.json
@@ -1,22 +1,22 @@
 {
     "description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK)",
     "homepage": "https://aws.amazon.com/corretto/",
-    "version": "17.0.19.10.1",
+    "version": "21.0.11.10.1",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://corretto.aws/downloads/resources/17.0.19.10.1/amazon-corretto-17.0.19.10.1-windows-x64-jdk.zip",
-            "hash": "ab748d9814d99a848916b54b36ae0f1d104493e61a19e1887072b4db9802c6ac"
+            "url": "https://corretto.aws/downloads/resources/21.0.11.10.1/amazon-corretto-21.0.11.10.1-windows-x64-jdk.zip",
+            "hash": "5d63fdb5a19393081919afc0daa4ce82a7fadcced569981a995529caed28fb14"
         }
     },
-    "extract_dir": "jdk17.0.19_10",
+    "extract_dir": "jdk21.0.11_10",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
     },
     "checkver": {
         "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
-        "jsonpath": "$.windows.x64.jdk.17.zip.resource",
+        "jsonpath": "$.windows.x64.jdk.21.zip.resource",
         "regex": "/([\\d.]+)/"
     },
     "autoupdate": {
@@ -25,7 +25,7 @@
                 "url": "https://corretto.aws/downloads/resources/$version/amazon-corretto-$version-windows-x64-jdk.zip",
                 "hash": {
                     "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
-                    "jsonpath": "$.windows.x64.jdk.17.zip.checksum_sha256"
+                    "jsonpath": "$.windows.x64.jdk.21.zip.checksum_sha256"
                 }
             }
         },

--- a/bucket/graalvm.json
+++ b/bucket/graalvm.json
@@ -1,23 +1,28 @@
 {
     "description": "High-performance, embeddable, polyglot Virtual Machine for JVM-langs (Java, Scala, Kotlin), JavaScript/NodeJS, Python, Ruby, R, and LLVM-langs (C, C++, Rust)",
-    "version": "22.3.1",
+    "version": "25.0.2",
     "homepage": "https://www.graalvm.org/",
     "license": "GPL-2.0",
-    "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.1/graalvm-ce-java19-windows-amd64-22.3.1.zip",
-    "hash": "f7250a997f0c251a78a447d38e9bd791ba2e35240d70338694cc6b9003a1ff4b",
-    "extract_dir": "graalvm-ce-java19-22.3.1",
+    "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-25.0.2/graalvm-community-jdk-25.0.2_windows-x64_bin.zip",
+    "hash": "72edc27ce2dd3c156332144a339c97995745cae291205ed2f9b5cc26aa9cb422",
+    "extract_to": "tmp",
+    "installer": {
+        "script": [
+            "(Get-ChildItem -Directory \"$dir\\tmp\").FullName | % { Move-Item \"$_\\*\" \"$dir\" }",
+            "Remove-Item -Recurse \"$dir\\tmp\""
+        ]
+    },
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir",
         "GRAALVM_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://www.graalvm.org/downloads/",
-        "regex": "vm-([\\d.]+)"
+        "url": "https://github.com/graalvm/graalvm-ce-builds/releases/latest",
+        "regex": "jdk-(25[\\d.]*)"
     },
     "autoupdate": {
-        "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$version/graalvm-ce-java19-windows-amd64-$version.zip",
-        "extract_dir": "graalvm-ce-java19-$version",
+        "url": "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-$version/graalvm-community-jdk-$version_windows-x64_bin.zip",
         "hash": {
             "url": "$url.sha256"
         }


### PR DESCRIPTION
## Summary

Update to point to JDK 21 (current LTS release) instead of JDK 17.

- version: 17.0.19.10.1 -> 21.0.11.10.1
- extract_dir: jdk17.0.19_10 -> jdk21.0.11_10
- checkver jsonpath: 17 -> 21

Closes #553

## Validation

```
checkver.ps1 corretto-lts-jdk -> 21.0.11.10.1
checkurls.ps1 corretto-lts-jdk -> [1][1][0]
```