### PR TITLE
corretto-lts-jdk: update from JDK 17 to JDK 21

### DIFF
--- a/bucket/corretto-lts-jdk.json
+++ b/bucket/corretto-lts-jdk.json
@@ -1,22 +1,22 @@
 {
     "description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK)",
     "homepage": "https://aws.amazon.com/corretto/",
-    "version": "17.0.19.10.1",
+    "version": "21.0.11.10.1",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://corretto.aws/downloads/resources/17.0.19.10.1/amazon-corretto-17.0.19.10.1-windows-x64-jdk.zip",
-            "hash": "ab748d9814d99a848916b54b36ae0f1d104493e61a19e1887072b4db9802c6ac"
+            "url": "https://corretto.aws/downloads/resources/21.0.11.10.1/amazon-corretto-21.0.11.10.1-windows-x64-jdk.zip",
+            "hash": "5d63fdb5a19393081919afc0daa4ce82a7fadcced569981a995529caed28fb14"
         }
     },
-    "extract_dir": "jdk17.0.19_10",
+    "extract_dir": "jdk21.0.11_10",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
     },
     "checkver": {
         "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
-        "jsonpath": "$.windows.x64.jdk.17.zip.resource",
+        "jsonpath": "$.windows.x64.jdk.21.zip.resource",
         "regex": "/([\\d.]+)/"
     },
     "autoupdate": {
@@ -25,7 +25,7 @@
                 "url": "https://corretto.aws/downloads/resources/$version/amazon-corretto-$version-windows-x64-jdk.zip",
                 "hash": {
                     "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
-                    "jsonpath": "$.windows.x64.jdk.17.zip.checksum_sha256"
+                    "jsonpath": "$.windows.x64.jdk.21.zip.checksum_sha256"
                 }
             }
         },


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Closes #553

## Summary

Update to point to JDK 21 (current LTS release) instead of JDK 17.

- version: `17.0.19.10.1` -> `21.0.11.10.1`
- extract_dir: `jdk17.0.19_10` -> `jdk21.0.11_10`
- checkver jsonpath: `17` -> `21`

## Validation

```
checkver.ps1 corretto-lts-jdk -> 21.0.11.10.1
checkurls.ps1 corretto-lts-jdk -> [1][1][0]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Amazon Corretto JDK to version 21.0.11.10.1, including updated Windows x64 package URL and verification checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->