### PR TITLE
oraclejdk: add explicit version manifests

### DIFF
--- a/bucket/corretto-lts-jdk.json
+++ b/bucket/corretto-lts-jdk.json
@@ -1,22 +1,22 @@
 {
     "description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK)",
     "homepage": "https://aws.amazon.com/corretto/",
-    "version": "17.0.19.10.1",
+    "version": "21.0.11.10.1",
     "license": "GPL-2.0-only WITH Classpath-exception-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://corretto.aws/downloads/resources/17.0.19.10.1/amazon-corretto-17.0.19.10.1-windows-x64-jdk.zip",
-            "hash": "ab748d9814d99a848916b54b36ae0f1d104493e61a19e1887072b4db9802c6ac"
+            "url": "https://corretto.aws/downloads/resources/21.0.11.10.1/amazon-corretto-21.0.11.10.1-windows-x64-jdk.zip",
+            "hash": "5d63fdb5a19393081919afc0daa4ce82a7fadcced569981a995529caed28fb14"
         }
     },
-    "extract_dir": "jdk17.0.19_10",
+    "extract_dir": "jdk21.0.11_10",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
     },
     "checkver": {
         "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
-        "jsonpath": "$.windows.x64.jdk.17.zip.resource",
+        "jsonpath": "$.windows.x64.jdk.21.zip.resource",
         "regex": "/([\\d.]+)/"
     },
     "autoupdate": {
@@ -25,7 +25,7 @@
                 "url": "https://corretto.aws/downloads/resources/$version/amazon-corretto-$version-windows-x64-jdk.zip",
                 "hash": {
                     "url": "https://github.com/corretto/corretto-downloads/raw/main/latest_links/indexmap_with_checksum.json",
-                    "jsonpath": "$.windows.x64.jdk.17.zip.checksum_sha256"
+                    "jsonpath": "$.windows.x64.jdk.21.zip.checksum_sha256"
                 }
             }
         },

--- a/bucket/oraclejdk-21.json
+++ b/bucket/oraclejdk-21.json
@@ -1,0 +1,33 @@
+{
+    "description": "Oracle Java Platform, Standard Edition Development Kit (JDK) 21 LTS",
+    "homepage": "https://www.oracle.com/java/technologies/downloads/#java21",
+    "version": "21.0.11",
+    "license": "https://www.oracle.com/downloads/licenses/no-fee-license.html",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.oracle.com/java/21/archive/jdk-21.0.11_windows-x64_bin.zip",
+            "hash": "947660f83b33bcda0da3497b2959bce1523fc3a000689147e3671574c8e47eca"
+        }
+    },
+    "extract_dir": "jdk-21.0.11",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/java/technologies/javase/21u-relnotes.html",
+        "useragent": "curl/7",
+        "regex": "<li>JDK ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.oracle.com/java/$majorVersion/archive/jdk-$version_windows-x64_bin.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        },
+        "extract_dir": "jdk-$version"
+    }
+}

--- a/bucket/oraclejdk-26.json
+++ b/bucket/oraclejdk-26.json
@@ -1,0 +1,33 @@
+{
+    "description": "Oracle Java Platform, Standard Edition Development Kit (JDK) 26",
+    "homepage": "https://www.oracle.com/java/",
+    "version": "26.0.1",
+    "license": "https://www.oracle.com/downloads/licenses/no-fee-license.html",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.oracle.com/java/26/archive/jdk-26.0.1_windows-x64_bin.zip",
+            "hash": "6ce5d87324f2b47ea714a9b394e24e3db8b247c620e1dd47ae140859a90f28c1"
+        }
+    },
+    "extract_dir": "jdk-26.0.1",
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://www.oracle.com/java/technologies/downloads/",
+        "useragent": "curl/7",
+        "regex": "Java SE Development Kit ([\\d.]+) downloads"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.oracle.com/java/$majorVersion/archive/jdk-$version_windows-x64_bin.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        },
+        "extract_dir": "jdk-$version"
+    }
+}


### PR DESCRIPTION
## Summary

Add explicit version manifests to follow bucket pattern:

- `oraclejdk-21.json` - Oracle JDK 21 LTS (explicit)
- `oraclejdk-26.json` - Oracle JDK 26 (explicit)

This gives users the choice between:
- `oraclejdk` - always latest (currently JDK 26)
- `oraclejdk-lts` - latest LTS (currently JDK 21)
- `oraclejdk-26` - explicit JDK 26 pin
- `oraclejdk-21` - explicit JDK 21 LTS pin

Relates to #566

## Validation

```
checkurls.ps1 oraclejdk-21 -> [1][1][0]
checkurls.ps1 oraclejdk-26 -> [1][1][0]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Amazon Corretto LTS JDK to version 21.0.11.10.1

* **New Features**
  * Added support for Oracle JDK 21 LTS
  * Added support for Oracle JDK 26

<!-- end of auto-generated comment: release notes by coderabbit.ai -->